### PR TITLE
Only owner can run action

### DIFF
--- a/.github/workflows/create-pr-from-issue.yml
+++ b/.github/workflows/create-pr-from-issue.yml
@@ -11,6 +11,12 @@ jobs:
   autopr:
     runs-on: ubuntu-latest
     steps:
+    - name: Check if issue is created by owner
+      run: |
+        if [ "${{ github.event.issue.user.login }}" != "${{ github.repository_owner }}" ]; then
+            echo "Issue not created by the owner. Skipping action.";
+            exit 78;
+          fi
     - name: Checkout
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/create-pr-from-issue.yml
+++ b/.github/workflows/create-pr-from-issue.yml
@@ -19,7 +19,7 @@ jobs:
     - name: AutoPR
       uses: ./
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ secrets.GH_TOKEN }}
         openai_api_key: ${{ secrets.OPENAI_API_KEY }}
         issue_number: ${{ github.event.issue.number }}
         issue_title: ${{ github.event.issue.title }}

--- a/README.md
+++ b/README.md
@@ -65,3 +65,5 @@ jobs:
 
 Whenever a new issue is opened or edited, the action will push a branch named `autopr/issue-#` and open a pull request to the base branch.
 Please note that if the branch already exists (on issue edit), it will be overwritten.
+
+- Credit to [Irgolic](https://github.com/irgolic/AutoPR) for creating this repo..

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ The following input variables are used by the action:
 
 To include this Github action in your own repository, you can use the following example in your workflow file:
 
+  # Only run the action if the issue is created by the repository owner
+  if: github.event.issue.user.login == github.repository_owner
+
 ```yaml
 on:
   issues:

--- a/workflows/create-pr-from-issue.yml
+++ b/workflows/create-pr-from-issue.yml
@@ -1,0 +1,6 @@
+      - name: Check if issue is created by owner
+        run: |
+          if [ "${{ github.event.issue.user.login }}" != "${{ github.repository_owner }}" ]; then
+            echo "Issue not created by the owner. Skipping action.";
+            exit 78;
+          fi


### PR DESCRIPTION
Also a minor change: GITHUB_TOKEN should be GH_TOKEN because GitHub disallowed GITHUB prefix on large accounts for security reasons.