### PR TITLE
Restrict run priviliges to collaborators

### DIFF
--- a/.github/workflows/create-pr-from-issue.yml
+++ b/.github/workflows/create-pr-from-issue.yml
@@ -11,6 +11,12 @@ jobs:
   autopr:
     runs-on: ubuntu-latest
     steps:
+    - name: Check if issue is created by owner
+      run: |
+        if [ "${{ github.event.issue.user.login }}" != "${{ github.repository_owner }}" ]; then
+            echo "Issue not created by the owner. Skipping action.";
+            exit 78;
+          fi
     - name: Checkout
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/create-pr-from-issue.yml
+++ b/.github/workflows/create-pr-from-issue.yml
@@ -11,12 +11,19 @@ jobs:
   autopr:
     runs-on: ubuntu-latest
     steps:
-    - name: Check if issue is created by owner
+    - name: Install jq
+      run: sudo apt-get install jq
+    - name: Check if issue is created by collaborator
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        if [ "${{ github.event.issue.user.login }}" != "${{ github.repository_owner }}" ]; then
-            echo "Issue not created by the owner. Skipping action.";
-            exit 78;
-          fi
+        is_collaborator=$(curl -s -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" \
+          "https://api.github.com/repos/${{ github.repository }}/collaborators/${{ github.event.issue.user.login }}" | jq -r '.message')
+
+        if [ "$is_collaborator" == "Not Found" ]; then
+          echo "Issue not created by a collaborator. Skipping action."
+          exit 78
+        fi
     - name: Checkout
       uses: actions/checkout@v2
       with:

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ The following input variables are used by the action:
 
 To include this Github action in your own repository, you can use the following example in your workflow file:
 
+  # Only run the action if the issue is created by the repository owner
+  if: github.event.issue.user.login == github.repository_owner
+
 ```yaml
 on:
   issues:

--- a/README.md
+++ b/README.md
@@ -41,12 +41,19 @@ jobs:
   autopr:
     runs-on: ubuntu-latest
     steps:
-    - name: Check if issue is created by owner
+    - name: Install jq
+      run: sudo apt-get install jq
+    - name: Check if issue is created by collaborator
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        if [ "${{ github.event.issue.user.login }}" != "${{ github.repository_owner }}" ]; then
-            echo "Issue not created by the owner. Skipping action.";
-            exit 78;
-          fi
+        is_collaborator=$(curl -s -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" \
+          "https://api.github.com/repos/${{ github.repository }}/collaborators/${{ github.event.issue.user.login }}" | jq -r '.message')
+
+        if [ "$is_collaborator" == "Not Found" ]; then
+          echo "Issue not created by a collaborator. Skipping action."
+          exit 78
+        fi
     - name: Checkout
       uses: actions/checkout@v2
       with:
@@ -55,12 +62,13 @@ jobs:
     - name: AutoPR
       uses: ./
       with:
-        github_token: ${{ secrets.GH_TOKEN }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
         openai_api_key: ${{ secrets.OPENAI_API_KEY }}
         issue_number: ${{ github.event.issue.number }}
         issue_title: ${{ github.event.issue.title }}
         issue_body: ${{ github.event.issue.body }}
         base_branch: main
+
 ```
 
 Whenever a new issue is opened or edited, the action will push a branch named `autopr/issue-#` and open a pull request to the base branch.


### PR DESCRIPTION
Thanks for the contribution @acheong08, I've adjusted the PR a bit and pushed it into a branch on this repo (I didn't want to force push into your main). Especially, thanks for catching the permissions lines in the README.

This PR attempts to restrict run privilege to only collaborators (incl. owners).