### PR TITLE
Add tests to CI

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,21 @@
+name: Run Tests
+
+on: [push, pull_request]
+
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - name: Install dependencies and run tests
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest
+        pytest autopr/tests/


### PR DESCRIPTION
This PR addresses issue #16. It adds a GitHub Actions workflow to automatically run the tests located in the autopr/tests/ directory using pytest.

Please review the changes and let me know if there's anything else needed.