### PR TITLE
Granular unidiff parsing

### DIFF
--- a/autopr/services/generation_service.py
+++ b/autopr/services/generation_service.py
@@ -257,7 +257,7 @@ class GenerationService:
         patch: Diff = self.rail_service.run_rail(rail)
         if patch is None:
             raise ValueError('Error generating patch')
-        patch_text = patch.diff or ''
+        patch_text = patch._text
 
         # if not all chunks were looked at, keep running the rail until all chunks are looked at
         not_looked_at_files = []
@@ -295,7 +295,7 @@ class GenerationService:
             patch: Diff = self.rail_service.run_rail(rail)
             if patch is None:
                 raise ValueError('Error generating patch')
-            patch_text += patch.diff or ''
+            patch_text += patch.to_str()
             update_not_looked_at_files()
 
         return patch_text

--- a/autopr/services/rail_service.py
+++ b/autopr/services/rail_service.py
@@ -83,7 +83,7 @@ class RailService:
             rail_spec,  # make sure to import custom validators before this
             num_reasks=self.num_reasks,
         )
-        length = self.calculate_prompt_length(rail)
+        length = self.calculate_rail_length(rail, raw_response)
         max_tokens = min(self.max_tokens, self.context_limit - length)
         options = {
             'model': self.completion_model,
@@ -153,3 +153,7 @@ class RailService:
     def calculate_prompt_length(self, rail: RailUnion) -> int:
         prompt = self.get_prompt_message(rail)
         return len(self.tokenizer.encode(prompt))
+
+    def calculate_rail_length(self, rail: RailUnion, raw_response: str) -> int:
+        rail_message = self.get_rail_message(rail, raw_response)
+        return len(self.tokenizer.encode(rail_message))

--- a/autopr/tests/resources/unidiff/.gptignore/correct.diff.json
+++ b/autopr/tests/resources/unidiff/.gptignore/correct.diff.json
@@ -1,0 +1,16 @@
+{
+    "hunks": [
+        {
+            "file": ".gptignore",
+            "new_file": true,
+            "start_line": 1,
+            "lines": [
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "*.lock"
+                }
+            ]
+        }
+    ]
+}

--- a/autopr/tests/resources/unidiff/.gptignore/wrong_minus_filename.diff.json
+++ b/autopr/tests/resources/unidiff/.gptignore/wrong_minus_filename.diff.json
@@ -1,0 +1,38 @@
+{
+    "hunks": [
+        {
+            "file": ".gptignore",
+            "new_file": false,
+            "start_line": 1,
+            "lines": [
+                {
+                    "role": "r",
+                    "indent_spaces": 0,
+                    "content": "--- .gptignore"
+                }
+            ]
+        },
+        {
+            "file": ".gptignore_new",
+            "new_file": true,
+            "start_line": 1,
+            "lines": [
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "+++ .gptignore_new"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "@@ -0,0 +1 @@"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 1,
+                    "content": "*.lock"
+                }
+            ]
+        }
+    ]
+}

--- a/autopr/tests/resources/unidiff/Dockerfile/a_b_filename.diff.json
+++ b/autopr/tests/resources/unidiff/Dockerfile/a_b_filename.diff.json
@@ -1,0 +1,21 @@
+{
+    "hunks": [
+        {
+            "file": "Dockerfile",
+            "new_file": false,
+            "start_line": 5,
+            "lines": [
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "COPY entrypoint.sh /entrypoint.sh"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "RUN chmod +x /entrypoint.sh"
+                }
+            ]
+        }
+    ]
+}

--- a/autopr/tests/resources/unidiff/Dockerfile/correct.diff.json
+++ b/autopr/tests/resources/unidiff/Dockerfile/correct.diff.json
@@ -1,0 +1,41 @@
+{
+    "hunks": [
+        {
+            "file": "Dockerfile",
+            "new_file": false,
+            "start_line": 6,
+            "lines": [
+                {
+                    "role": "r",
+                    "indent_spaces": 0,
+                    "content": "# Set up entrypoint"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "# Set up entrypoint"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 1,
+                    "content": "COPY entrypoint.sh /entrypoint.sh"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "# Make entrypoint executable"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 1,
+                    "content": "RUN chmod +x /entrypoint.sh"
+                },
+                {
+                    "role": "u",
+                    "indent_spaces": 0,
+                    "content": "# Run the app"
+                }
+            ]
+        }
+    ]
+}

--- a/autopr/tests/resources/unidiff/Dockerfile/hallucinated_lines.diff.json
+++ b/autopr/tests/resources/unidiff/Dockerfile/hallucinated_lines.diff.json
@@ -1,0 +1,55 @@
+{
+    "hunks": [
+        {
+            "file": "Dockerfile",
+            "new_file": false,
+            "start_line": 5,
+            "lines": [
+                {
+                    "role": "r",
+                    "indent_spaces": 0,
+                    "content": "COPY entrypoint.sh /entrypoint.sh"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "COPY entrypoint.sh /entrypoint.sh"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "HUHU"
+                }
+            ]
+        },
+        {
+            "file": "Dockerfile",
+            "new_file": false,
+            "start_line": 9,
+            "lines": [
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "RUN chmod +x /entrypoint.sh"
+                }
+            ]
+        },
+        {
+            "file": "Dockerfile",
+            "new_file": false,
+            "start_line": 11,
+            "lines": [
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "HIHI"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "HAHA"
+                }
+            ]
+        }
+    ]
+}

--- a/autopr/tests/resources/unidiff/Dockerfile/plus_name_is_wrong.diff.json
+++ b/autopr/tests/resources/unidiff/Dockerfile/plus_name_is_wrong.diff.json
@@ -1,0 +1,31 @@
+{
+    "hunks": [
+        {
+            "file": "Dockerfile",
+            "new_file": false,
+            "start_line": 5,
+            "lines": [
+                {
+                    "role": "r",
+                    "indent_spaces": 0,
+                    "content": "COPY entrypoint.sh /entrypoint.sh"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "COPY entrypoint.sh /entrypoint.sh"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "# Make entrypoint executable"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "RUN chmod +x /entrypoint.sh"
+                }
+            ]
+        }
+    ]
+}

--- a/autopr/tests/resources/unidiff/Dockerfile/wrong_line_counts.diff.json
+++ b/autopr/tests/resources/unidiff/Dockerfile/wrong_line_counts.diff.json
@@ -1,0 +1,51 @@
+{
+    "hunks": [
+        {
+            "file": "Dockerfile",
+            "new_file": false,
+            "start_line": 5,
+            "lines": [
+                {
+                    "role": "r",
+                    "indent_spaces": 0,
+                    "content": "--- Dockerfile"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "+++ Dockerfile"
+                },
+                {
+                    "role": "u",
+                    "indent_spaces": 0,
+                    "content": "@@ -5,505 +5,10 @@"
+                },
+                {
+                    "role": "u",
+                    "indent_spaces": 0,
+                    "content": "# Set up entrypoint"
+                },
+                {
+                    "role": "u",
+                    "indent_spaces": 1,
+                    "content": "COPY entrypoint.sh /entrypoint.sh"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 1,
+                    "content": "# Make entrypoint executable"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 1,
+                    "content": "RUN chmod +x /entrypoint.sh"
+                },
+                {
+                    "role": "u",
+                    "indent_spaces": 0,
+                    "content": "# Run the app"
+                }
+            ]
+        }
+    ]
+}

--- a/autopr/tests/resources/unidiff/Dockerfile_multihunk/correct.diff.json
+++ b/autopr/tests/resources/unidiff/Dockerfile_multihunk/correct.diff.json
@@ -1,0 +1,53 @@
+{
+    "hunks": [
+        {
+            "file": "Dockerfile_multihunk",
+            "new_file": false,
+            "start_line": 3,
+            "lines": [
+                {
+                    "role": "r",
+                    "indent_spaces": 0,
+                    "content": "# Install git"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": ""
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 1,
+                    "content": "RUN apt-get update && apt-get install -y git"
+                }
+            ]
+        },
+        {
+            "file": "Dockerfile_multihunk",
+            "new_file": false,
+            "start_line": 8,
+            "lines": [
+                {
+                    "role": "r",
+                    "indent_spaces": 1,
+                    "content": "RUN chmod +x /entrypoint.sh"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "Ha"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 1,
+                    "content": "Haha"
+                },
+                {
+                    "role": "r",
+                    "indent_spaces": 0,
+                    "content": "# Run the app"
+                }
+            ]
+        }
+    ]
+}

--- a/autopr/tests/resources/unidiff/Dockerfile_multihunk/incorrect.diff.json
+++ b/autopr/tests/resources/unidiff/Dockerfile_multihunk/incorrect.diff.json
@@ -1,0 +1,38 @@
+{
+    "hunks": [
+        {
+            "file": "Dockerfile_multihunk",
+            "new_file": false,
+            "start_line": 1,
+            "lines": [
+                {
+                    "role": "a",
+                    "indent_spaces": 1,
+                    "content": "Install git"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 1,
+                    "content": "RUN apt-get update && apt-get install -y git"
+                }
+            ]
+        },
+        {
+            "file": "Dockerfile_multihunk",
+            "new_file": false,
+            "start_line": 9,
+            "lines": [
+                {
+                    "role": "a",
+                    "indent_spaces": 1,
+                    "content": "Ha"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 1,
+                    "content": "Haha"
+                }
+            ]
+        }
+    ]
+}

--- a/autopr/tests/resources/unidiff/Dockerfile_wrong_line_number_tolerance/correct.diff.json
+++ b/autopr/tests/resources/unidiff/Dockerfile_wrong_line_number_tolerance/correct.diff.json
@@ -1,0 +1,31 @@
+{
+    "hunks": [
+        {
+            "file": "Dockerfile_wrong_line_number_tolerance",
+            "new_file": false,
+            "start_line": 4,
+            "lines": [
+                {
+                    "role": "r",
+                    "indent_spaces": 0,
+                    "content": "# Set up entrypoint"
+                },
+                {
+                    "role": "r",
+                    "indent_spaces": 1,
+                    "content": "COPY entrypoint.sh /entrypoint.sh"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "# Make entrypoint executable"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 1,
+                    "content": "RUN chmod +x /entrypoint.sh"
+                }
+            ]
+        }
+    ]
+}

--- a/autopr/tests/resources/unidiff/Dockerfile_wrong_line_number_tolerance/wrong_line_counts.diff.json
+++ b/autopr/tests/resources/unidiff/Dockerfile_wrong_line_number_tolerance/wrong_line_counts.diff.json
@@ -1,0 +1,36 @@
+{
+    "hunks": [
+        {
+            "file": "Dockerfile_wrong_line_number_tolerance",
+            "new_file": false,
+            "start_line": 6,
+            "lines": [
+                {
+                    "role": "r",
+                    "indent_spaces": 0,
+                    "content": "COPY entrypoint.sh /entrypoint.sh"
+                },
+                {
+                    "role": "r",
+                    "indent_spaces": 0,
+                    "content": "RUN chmod +x /entrypoint.sh"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "COPY entrypoint.sh /entrypoint.sh"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "# Make entrypoint executable"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "RUN chmod +x /entrypoint.sh"
+                }
+            ]
+        }
+    ]
+}

--- a/autopr/tests/resources/unidiff/README.md/correct.diff.json
+++ b/autopr/tests/resources/unidiff/README.md/correct.diff.json
@@ -1,0 +1,121 @@
+{
+    "hunks": [
+        {
+            "file": "README.md",
+            "new_file": false,
+            "start_line": 1,
+            "lines": [
+                {
+                    "role": "r",
+                    "indent_spaces": 0,
+                    "content": "# Pull Request Drafter Github Action"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "# Automatic Pull Request Github Action \ud83c\udf89\ud83d\ude80"
+                },
+                {
+                    "role": "u",
+                    "indent_spaces": 0,
+                    "content": ""
+                },
+                {
+                    "role": "r",
+                    "indent_spaces": 0,
+                    "content": "## Environment Variables"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "## Input Variables"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": ""
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "The input variables for this Github Action are documented in `action.yml`. They include:"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": ""
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "- `github_token`"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "- `openai_api_key`"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "- `issue_number`"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "- `issue_title`"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "- `issue_body`"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "- `base_branch`"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": ""
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "## Guardrails Library"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": ""
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "This Github Action utilizes the guardrails library, which can be found in `generation_service.py` and `validators.py`. The library helps in generating and validating pull requests based on the input variables and the codebase."
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": ""
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "## Including the Github Action in Your Repository"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": ""
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "To include the Automatic Pull Request Github Action in your own repository, add its configuration to your `.github/workflows` directory. Follow the documentation in `action.yml` for further guidance."
+                }
+            ]
+        }
+    ]
+}

--- a/autopr/tests/resources/unidiff/README.md/incorrect.diff.json
+++ b/autopr/tests/resources/unidiff/README.md/incorrect.diff.json
@@ -1,0 +1,86 @@
+{
+    "hunks": [
+        {
+            "file": "README.md",
+            "new_file": false,
+            "start_line": 1,
+            "lines": [
+                {
+                    "role": "r",
+                    "indent_spaces": 0,
+                    "content": "# Pull Request Drafter Github Action"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "# Automatic Pull Request Github Action \ud83c\udf89\ud83d\ude80"
+                },
+                {
+                    "role": "r",
+                    "indent_spaces": 0,
+                    "content": "## Environment Variables"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "## Input Variables"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "The input variables for this Github Action are documented in `action.yml`. They include:"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "- `github_token`"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "- `openai_api_key`"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "- `issue_number`"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "- `issue_title`"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "- `issue_body`"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "- `base_branch`"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "## Guardrails Library"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "This Github Action utilizes the guardrails library, which can be found in `generation_service.py` and `validators.py`. The library helps in generating and validating pull requests based on the input variables and the codebase."
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "## Including the Github Action in Your Repository"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "To include the Automatic Pull Request Github Action in your own repository, add its configuration to your `.github/workflows` directory. Follow the documentation in `action.yml` for further guidance."
+                }
+            ]
+        }
+    ]
+}

--- a/autopr/tests/resources/unidiff/README_new.md/correct.diff.json
+++ b/autopr/tests/resources/unidiff/README_new.md/correct.diff.json
@@ -1,0 +1,31 @@
+{
+    "hunks": [
+        {
+            "file": "README_new.md",
+            "new_file": true,
+            "start_line": 1,
+            "lines": [
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "# Pull Request Drafter Github Action"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": ""
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "## Environment Variables"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": ""
+                }
+            ]
+        }
+    ]
+}

--- a/autopr/tests/resources/unidiff/README_new.md/missing_minus_filename.diff.json
+++ b/autopr/tests/resources/unidiff/README_new.md/missing_minus_filename.diff.json
@@ -1,0 +1,31 @@
+{
+    "hunks": [
+        {
+            "file": "README_new.md",
+            "new_file": true,
+            "start_line": 1,
+            "lines": [
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "# Pull Request Drafter Github Action"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": ""
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "## Environment Variables"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": ""
+                }
+            ]
+        }
+    ]
+}

--- a/autopr/tests/resources/unidiff/autopr%services%generation_service.py/correct.diff.json
+++ b/autopr/tests/resources/unidiff/autopr%services%generation_service.py/correct.diff.json
@@ -1,0 +1,130 @@
+{
+    "hunks": [
+        {
+            "file": "autopr/services/generation_service.py",
+            "new_file": false,
+            "start_line": 11,
+            "lines": [
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "from pathlib import Path"
+                }
+            ]
+        },
+        {
+            "file": "autopr/services/generation_service.py",
+            "new_file": false,
+            "start_line": 28,
+            "lines": [
+                {
+                    "role": "a",
+                    "indent_spaces": 8,
+                    "content": "self.create_gptignore()"
+                }
+            ]
+        },
+        {
+            "file": "autopr/services/generation_service.py",
+            "new_file": false,
+            "start_line": 67,
+            "lines": [
+                {
+                    "role": "a",
+                    "indent_spaces": 4,
+                    "content": "def _repo_to_files_and_token_lengths("
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 8,
+                    "content": "repo_tree: git.Repo,"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 8,
+                    "content": "excluded_files: list[str] = None,"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 8,
+                    "content": ") -> list[tuple[str, int]]:"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 8,
+                    "content": "files_with_token_lengths = []"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 8,
+                    "content": "for blob in repo_tree.traverse():"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 12,
+                    "content": "if blob.type == 'tree':"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 16,
+                    "content": "continue"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 12,
+                    "content": "if excluded_files is not None and blob.path in excluded_files:"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 16,
+                    "content": "continue"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 12,
+                    "content": "content = blob.data_stream.read().decode()"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 12,
+                    "content": "token_length = len(self.rail_service.tokenizer.encode(content))"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 12,
+                    "content": "files_with_token_lengths.append((blob.path, token_length))"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 8,
+                    "content": "return files_with_token_lengths"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 4,
+                    "content": "def create_gptignore(self):"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 8,
+                    "content": "gptignore_path = Path('.gptignore')"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 8,
+                    "content": "if not gptignore_path.exists():"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 12,
+                    "content": "with gptignore_path.open('w') as gptignore_file:"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 16,
+                    "content": "gptignore_file.write('*.lock"
+                }
+            ]
+        }
+    ]
+}

--- a/autopr/tests/resources/unidiff/autopr%services%generation_service.py/incorrect.diff.json
+++ b/autopr/tests/resources/unidiff/autopr%services%generation_service.py/incorrect.diff.json
@@ -1,0 +1,117 @@
+{
+    "hunks": [
+        {
+            "file": "autopr/services/generation_service.py",
+            "new_file": false,
+            "start_line": 11,
+            "lines": [
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "from pathlib import Path"
+                }
+            ]
+        },
+        {
+            "file": "autopr/services/generation_service.py",
+            "new_file": false,
+            "start_line": 28,
+            "lines": [
+                {
+                    "role": "a",
+                    "indent_spaces": 8,
+                    "content": "self.create_gptignore()"
+                }
+            ]
+        },
+        {
+            "file": "autopr/services/generation_service.py",
+            "new_file": false,
+            "start_line": 67,
+            "lines": [
+                {
+                    "role": "a",
+                    "indent_spaces": 4,
+                    "content": "def _repo_to_files_and_token_lengths("
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 8,
+                    "content": "files_with_token_lengths = []"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 8,
+                    "content": "for blob in repo_tree.traverse():"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 12,
+                    "content": "if blob.type == 'tree':"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 16,
+                    "content": "continue"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 12,
+                    "content": "if excluded_files is not None and blob.path in excluded_files:"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 16,
+                    "content": "continue"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 12,
+                    "content": "content = blob.data_stream.read().decode()"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 12,
+                    "content": "token_length = len(self.rail_service.tokenizer.encode(content))"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 12,
+                    "content": "files_with_token_lengths.append((blob.path, token_length))"
+                }
+            ]
+        },
+        {
+            "file": "autopr/services/generation_service.py",
+            "new_file": false,
+            "start_line": 69,
+            "lines": [
+                {
+                    "role": "a",
+                    "indent_spaces": 4,
+                    "content": "def create_gptignore(self):"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 8,
+                    "content": "gptignore_path = Path('.gptignore')"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 8,
+                    "content": "if not gptignore_path.exists():"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 12,
+                    "content": "with gptignore_path.open('w') as gptignore_file:"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 16,
+                    "content": "gptignore_file.write('*.lock"
+                }
+            ]
+        }
+    ]
+}

--- a/autopr/tests/resources/unidiff/autopr%services%generation_service_2.py/correct.diff.json
+++ b/autopr/tests/resources/unidiff/autopr%services%generation_service_2.py/correct.diff.json
@@ -1,0 +1,73 @@
+{
+    "hunks": [
+        {
+            "file": "autopr/services/generation_service_2.py",
+            "new_file": false,
+            "start_line": 1,
+            "lines": [
+                {
+                    "role": "r",
+                    "indent_spaces": 0,
+                    "content": "import tempfile"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "import fnmatch"
+                }
+            ]
+        },
+        {
+            "file": "autopr/services/generation_service_2.py",
+            "new_file": false,
+            "start_line": 315,
+            "lines": [
+                {
+                    "role": "r",
+                    "indent_spaces": 8,
+                    "content": "repo_tree = repo.head.commit.tree"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 8,
+                    "content": "with open('.gptignore', 'r') as gptignore_file:"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 12,
+                    "content": "ignore_patterns = gptignore_file.read().splitlines()"
+                },
+                {
+                    "role": "r",
+                    "indent_spaces": 8,
+                    "content": "filepaths = self.get_initial_filepaths(files, issue_text)"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 8,
+                    "content": "filepaths = ["
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 12,
+                    "content": "filepath for filepath in self.get_initial_filepaths(files, issue_text)"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 12,
+                    "content": "if not any(fnmatch.fnmatch(filepath, pattern) for pattern in ignore_patterns)"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 8,
+                    "content": "]"
+                },
+                {
+                    "role": "u",
+                    "indent_spaces": 8,
+                    "content": "if filepaths:"
+                }
+            ]
+        }
+    ]
+}

--- a/autopr/tests/resources/unidiff/autopr%services%generation_service_2.py/incorrect.diff.json
+++ b/autopr/tests/resources/unidiff/autopr%services%generation_service_2.py/incorrect.diff.json
@@ -1,0 +1,86 @@
+{
+    "hunks": [
+        {
+            "file": "autopr/services/generation_service_2.py",
+            "new_file": false,
+            "start_line": 1,
+            "lines": [
+                {
+                    "role": "r",
+                    "indent_spaces": 0,
+                    "content": "import tempfile"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "import fnmatch"
+                },
+                {
+                    "role": "u",
+                    "indent_spaces": 0,
+                    "content": "from typing import List, Dict, Tuple"
+                },
+                {
+                    "role": "u",
+                    "indent_spaces": 0,
+                    "content": "from git import Repo, Tree"
+                },
+                {
+                    "role": "u",
+                    "indent_spaces": 0,
+                    "content": "from .file_descriptor import FileDescriptor"
+                },
+                {
+                    "role": "r",
+                    "indent_spaces": 4,
+                    "content": "repo_tree = repo.head.commit.tree"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 4,
+                    "content": "with open('.gptignore', 'r') as gptignore_file:"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 8,
+                    "content": "ignore_patterns = gptignore_file.read().splitlines()"
+                },
+                {
+                    "role": "r",
+                    "indent_spaces": 4,
+                    "content": "filepaths = self.get_initial_filepaths(files, issue_text)"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 4,
+                    "content": "filepaths = ["
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 8,
+                    "content": "filepath for filepath in self.get_initial_filepaths(files, issue_text)"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 12,
+                    "content": "if not any(fnmatch.fnmatch(filepath, pattern) for pattern in ignore_patterns)"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 4,
+                    "content": "]"
+                },
+                {
+                    "role": "u",
+                    "indent_spaces": 4,
+                    "content": "if filepaths:"
+                },
+                {
+                    "role": "u",
+                    "indent_spaces": 8,
+                    "content": "notes = self.write_notes_about_files(files, issue_text, filepaths)"
+                }
+            ]
+        }
+    ]
+}

--- a/autopr/tests/resources/unidiff/autopr%validators.py/correct.diff.json
+++ b/autopr/tests/resources/unidiff/autopr%validators.py/correct.diff.json
@@ -1,0 +1,31 @@
+{
+    "hunks": [
+        {
+            "file": "autopr/validators.py",
+            "new_file": false,
+            "start_line": 106,
+            "lines": [
+                {
+                    "role": "r",
+                    "indent_spaces": 12,
+                    "content": "check_file_line = current_file_content[check_line_number]"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 12,
+                    "content": "if 0 <= check_line_number < len(current_file_content):"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 16,
+                    "content": "check_file_line = current_file_content[check_line_number]"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 16,
+                    "content": "if line[1:] == check_file_line:"
+                }
+            ]
+        }
+    ]
+}

--- a/autopr/tests/resources/unidiff/autopr%validators.py/correct.diff.json
+++ b/autopr/tests/resources/unidiff/autopr%validators.py/correct.diff.json
@@ -6,9 +6,24 @@
             "start_line": 106,
             "lines": [
                 {
+                    "role": "u",
+                    "indent_spaces": 8,
+                    "content": "for offset in range(-search_range, search_range + 1):"
+                },
+                {
+                    "role": "u",
+                    "indent_spaces": 12,
+                    "content": "check_line_number = current_line_number + offset"
+                },
+                {
                     "role": "r",
                     "indent_spaces": 12,
                     "content": "check_file_line = current_file_content[check_line_number]"
+                },
+                {
+                    "role": "r",
+                    "indent_spaces": 12,
+                    "content": "if 0 <= check_line_number < len(current_file_content) and line[1:] == check_file_line:"
                 },
                 {
                     "role": "a",
@@ -24,6 +39,21 @@
                     "role": "a",
                     "indent_spaces": 16,
                     "content": "if line[1:] == check_file_line:"
+                },
+                {
+                    "role": "u",
+                    "indent_spaces": 20,
+                    "content": "current_line_number = check_line_number + 1"
+                },
+                {
+                    "role": "u",
+                    "indent_spaces": 20,
+                    "content": "# Fix @@ line"
+                },
+                {
+                    "role": "u",
+                    "indent_spaces": 20,
+                    "content": "cleaned_lines[-1] = f\"@@ -{check_line_number + 1},1 +{check_line_number + 1},1 @@\""
                 }
             ]
         }

--- a/autopr/tests/resources/unidiff/autopr%validators.py/mixed_indentation_offset.diff.json
+++ b/autopr/tests/resources/unidiff/autopr%validators.py/mixed_indentation_offset.diff.json
@@ -1,0 +1,36 @@
+{
+    "hunks": [
+        {
+            "file": "autopr/validators.py",
+            "new_file": false,
+            "start_line": 105,
+            "lines": [
+                {
+                    "role": "r",
+                    "indent_spaces": 20,
+                    "content": "check_file_line = current_file_content[check_line_number]"
+                },
+                {
+                    "role": "r",
+                    "indent_spaces": 20,
+                    "content": "if 0 <= check_line_number < len(current_file_content) and line[1:] == check_file_line:"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 20,
+                    "content": "if 0 <= check_line_number < len(current_file_content):"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 24,
+                    "content": "check_file_line = current_file_content[check_line_number]"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 24,
+                    "content": "if line[1:] == check_file_line:"
+                }
+            ]
+        }
+    ]
+}

--- a/autopr/tests/resources/unidiff/autopr%validators.py/negative_indentation_offset.diff.json
+++ b/autopr/tests/resources/unidiff/autopr%validators.py/negative_indentation_offset.diff.json
@@ -1,0 +1,36 @@
+{
+    "hunks": [
+        {
+            "file": "autopr/validators.py",
+            "new_file": false,
+            "start_line": 105,
+            "lines": [
+                {
+                    "role": "r",
+                    "indent_spaces": 16,
+                    "content": "check_file_line = current_file_content[check_line_number]"
+                },
+                {
+                    "role": "r",
+                    "indent_spaces": 16,
+                    "content": "if 0 <= check_line_number < len(current_file_content) and line[1:] == check_file_line:"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 16,
+                    "content": "if 0 <= check_line_number < len(current_file_content):"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 20,
+                    "content": "check_file_line = current_file_content[check_line_number]"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 20,
+                    "content": "if line[1:] == check_file_line:"
+                }
+            ]
+        }
+    ]
+}

--- a/autopr/tests/resources/unidiff/autopr%validators.py/positive_indentation_offset.diff.json
+++ b/autopr/tests/resources/unidiff/autopr%validators.py/positive_indentation_offset.diff.json
@@ -1,0 +1,36 @@
+{
+    "hunks": [
+        {
+            "file": "autopr/validators.py",
+            "new_file": false,
+            "start_line": 105,
+            "lines": [
+                {
+                    "role": "r",
+                    "indent_spaces": 8,
+                    "content": "check_file_line = current_file_content[check_line_number]"
+                },
+                {
+                    "role": "r",
+                    "indent_spaces": 8,
+                    "content": "if 0 <= check_line_number < len(current_file_content) and line[1:] == check_file_line:"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 8,
+                    "content": "if 0 <= check_line_number < len(current_file_content):"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 12,
+                    "content": "check_file_line = current_file_content[check_line_number]"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 12,
+                    "content": "if line[1:] == check_file_line:"
+                }
+            ]
+        }
+    ]
+}

--- a/autopr/tests/resources/unidiff/tic_tac_toe.py/correct.diff.json
+++ b/autopr/tests/resources/unidiff/tic_tac_toe.py/correct.diff.json
@@ -1,0 +1,51 @@
+{
+    "hunks": [
+        {
+            "file": "tic_tac_toe.py",
+            "new_file": true,
+            "start_line": 1,
+            "lines": [
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "def display_board(board):"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 4,
+                    "content": "for i in range(3):"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 8,
+                    "content": "print(\" | \".join(board[i * 3:i * 3 + 3]))"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 8,
+                    "content": "if i < 2:"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 12,
+                    "content": "print(\"-\" * 9)"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "if __name__ == \"__main__\":"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 4,
+                    "content": "example_board = [\"1\", \"2\", \"3\", \"4\", \"5\", \"6\", \"7\", \"8\", \"9\"]"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 4,
+                    "content": "display_board(example_board)"
+                }
+            ]
+        }
+    ]
+}

--- a/autopr/tests/resources/unidiff/tic_tac_toe.py/incorrect.diff.json
+++ b/autopr/tests/resources/unidiff/tic_tac_toe.py/incorrect.diff.json
@@ -1,0 +1,51 @@
+{
+    "hunks": [
+        {
+            "file": "tic_tac_toe.py",
+            "new_file": true,
+            "start_line": 1,
+            "lines": [
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "def display_board(board):"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 4,
+                    "content": "for i in range(3):"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 8,
+                    "content": "print(\" | \".join(board[i * 3:i * 3 + 3]))"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 8,
+                    "content": "if i < 2:"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 12,
+                    "content": "print(\"-\" * 9)"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "if __name__ == \"__main__\":"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 4,
+                    "content": "example_board = [\"1\", \"2\", \"3\", \"4\", \"5\", \"6\", \"7\", \"8\", \"9\"]"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 4,
+                    "content": "display_board(example_board)"
+                }
+            ]
+        }
+    ]
+}

--- a/autopr/tests/resources/unidiff/tic_tac_toe.py/nonexistent_whitespace.diff.json
+++ b/autopr/tests/resources/unidiff/tic_tac_toe.py/nonexistent_whitespace.diff.json
@@ -1,0 +1,51 @@
+{
+    "hunks": [
+        {
+            "file": "tic_tac_toe.py",
+            "new_file": true,
+            "start_line": 1,
+            "lines": [
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "def display_board(board):"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 4,
+                    "content": "for i in range(3):"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 8,
+                    "content": "print(\" | \".join(board[i * 3:i * 3 + 3]))"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 8,
+                    "content": "if i < 2:"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 12,
+                    "content": "print(\"-\" * 9)"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "if __name__ == \"__main__\":"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 4,
+                    "content": "example_board = [\"1\", \"2\", \"3\", \"4\", \"5\", \"6\", \"7\", \"8\", \"9\"]"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 4,
+                    "content": "display_board(example_board)"
+                }
+            ]
+        }
+    ]
+}

--- a/autopr/tests/resources/unidiff/tic_tac_toe_2.py/correct.diff.json
+++ b/autopr/tests/resources/unidiff/tic_tac_toe_2.py/correct.diff.json
@@ -1,0 +1,83 @@
+{
+    "hunks": [
+        {
+            "file": "tic_tac_toe_2.py",
+            "new_file": false,
+            "start_line": 22,
+            "lines": [
+                {
+                    "role": "r",
+                    "indent_spaces": 0,
+                    "content": "def alternate_player(player):"
+                },
+                {
+                    "role": "r",
+                    "indent_spaces": 4,
+                    "content": "return \"X\" if player == \"O\" else \"O\""
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "def is_board_full(board):"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 4,
+                    "content": "for row in board:"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 8,
+                    "content": "if \" \" in row:"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 12,
+                    "content": "return False"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 8,
+                    "content": "return True"
+                }
+            ]
+        },
+        {
+            "file": "tic_tac_toe_2.py",
+            "new_file": false,
+            "start_line": 31,
+            "lines": [
+                {
+                    "role": "a",
+                    "indent_spaces": 4,
+                    "content": "while not check_winner(board, current_player) and not is_board_full(board):"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 8,
+                    "content": "row, col = map(int, input(\"Enter your move (row, col): \").split(\",\"))"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 8,
+                    "content": "board[row-1][col-1] = current_player"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 8,
+                    "content": "display_board(board)"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 8,
+                    "content": "current_player = alternate_player(current_player)"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 4,
+                    "content": "print(\"Game Over!\")"
+                }
+            ]
+        }
+    ]
+}

--- a/autopr/tests/resources/unidiff/tic_tac_toe_2.py/incorrect.diff.json
+++ b/autopr/tests/resources/unidiff/tic_tac_toe_2.py/incorrect.diff.json
@@ -1,0 +1,91 @@
+{
+    "hunks": [
+        {
+            "file": "tic_tac_toe_2.py",
+            "new_file": false,
+            "start_line": 18,
+            "lines": [
+                {
+                    "role": "r",
+                    "indent_spaces": 0,
+                    "content": "def alternate_player(player):"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "def is_board_full(board):"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 4,
+                    "content": "for row in board:"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 8,
+                    "content": "if \" \" in row:"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 12,
+                    "content": "return False"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 4,
+                    "content": "return True"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 0,
+                    "content": "if __name__ == \"__main__\":"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 4,
+                    "content": "board = [[\" \" for _ in range(3)] for _ in range(3)]"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 4,
+                    "content": "current_player = \"X\""
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 4,
+                    "content": "display_board(board)"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 4,
+                    "content": "while not check_winner(board, current_player) and not is_board_full(board):"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 8,
+                    "content": "row, col = map(int, input(\"Enter your move (row, col): \").split(\",\"))"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 8,
+                    "content": "board[row-1][col-1] = current_player"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 8,
+                    "content": "display_board(board)"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 8,
+                    "content": "current_player = alternate_player(current_player)"
+                },
+                {
+                    "role": "a",
+                    "indent_spaces": 4,
+                    "content": "print(\"Game Over!\")"
+                }
+            ]
+        }
+    ]
+}

--- a/autopr/tests/scripts/generate_diff_models.py
+++ b/autopr/tests/scripts/generate_diff_models.py
@@ -1,0 +1,96 @@
+import os
+import json
+import tempfile
+import threading
+
+import git
+
+from autopr.models.rail_objects import Diff
+from autopr.models.rails import NewDiff
+from autopr.services.diff_service import PatchService
+from autopr.services.rail_service import RailService
+from autopr.validators import create_unidiff_validator
+
+
+def process_diff_file(diff_path, rail_service):
+    print(f'Processing {diff_path}...')
+    json_path = os.path.join(os.path.dirname(diff_path), f'{os.path.basename(diff_path)}.json')
+    # If json file already exists, skip
+    if os.path.exists(json_path):
+        return
+
+    # Read diff file
+    with open(diff_path, 'r') as f:
+        diff = f.read()
+
+    # Run rail over the diff file and save dict output
+    raw_o, dict_o = rail_service._run_rail(NewDiff, diff)
+    with open(json_path, 'w') as f:
+        json.dump(json.loads(raw_o), f, indent=4)
+    print(f'Processed {diff_path}!')
+
+
+def main():
+    # Load diff files from ../resources/unidiff
+    path = os.path.join(os.path.dirname(__file__), '..', 'resources', 'unidiff')
+    path = os.path.normpath(path)
+
+    # Create temporary directory, put the files in
+    tmp_dir = tempfile.TemporaryDirectory()
+    # For each folder in ../resources/unidiff, create a file
+    for dirname in os.listdir(path):
+        if '%' in dirname:
+            filepath = dirname.replace('%', '/')
+            filename = filepath.split('/')[-1]
+            dirname_stem = os.path.dirname(filepath)
+
+            # Create dir if file is in a subdirectory
+            tmpdir_dirpath = os.path.join(tmp_dir.name, dirname_stem)
+            os.makedirs(tmpdir_dirpath, exist_ok=True)
+            tmpdir_filepath = os.path.join(tmpdir_dirpath, filename)
+        else:
+            filename = dirname
+            tmpdir_filepath = os.path.join(tmp_dir.name, dirname)
+        # Copy nested file with same name as filename
+        resource_filepath = os.path.join(path, dirname, filename)
+        if os.path.exists(resource_filepath):
+            with open(resource_filepath, 'r') as f:
+                file_contents = f.read()
+            with open(tmpdir_filepath, 'w') as f:
+                f.write(file_contents)
+
+    # Init repo
+    repo = git.Repo.init(tmp_dir.name)
+    # Create main branch
+    repo.git.checkout('-b', 'main')
+    # Create a commit
+    repo.git.execute(['git', 'add', '-A'])
+    # Commit, Allow empty
+    repo.git.execute(['git', 'commit', '--allow-empty', '-m', 'Initial commit'])
+
+    # For each diff in ../resources/unidiff (recursively), generate a `.diff.json` file
+    # that reflects the structure in the Diff model
+    rail_service = RailService(
+        completion_model='gpt-4',
+    )
+    diff_service = PatchService(
+        repo=repo,
+    )
+
+    # Create guardrails validator
+    create_unidiff_validator(repo, diff_service)
+
+    threads = []
+    for root, dirs, files in os.walk(path):
+        for filename in files:
+            if filename.endswith('.diff'):
+                diff_path = os.path.join(root, filename)
+                t = threading.Thread(target=process_diff_file, args=(diff_path, rail_service))
+                threads.append(t)
+                t.start()
+
+    for t in threads:
+        t.join()
+
+if __name__ == '__main__':
+    main()

--- a/autopr/validators.py
+++ b/autopr/validators.py
@@ -394,3 +394,32 @@ def create_filepath_validator(repo: git.Repo):
             return error.schema
 
     return register_validator(name="filepath", data_type="string")(FilePath)
+
+
+@register_validator(name="no-leading-whitespace", data_type="string")
+class NoLeadingWhitespace(Validator):
+    """Validate value does not have leading whitespace.
+    - Name for `format` attribute: `no-leading-whitespace`
+    - Supported data types: `string`
+    """
+    def validate(self, key: str, value: Any, schema: Union[Dict, List]) -> Dict:
+        log.debug("Validating no-leading-whitespace...", key=key, value=value)
+
+        if value.startswith(" "):
+            raise EventDetail(
+                key,
+                value,
+                schema,
+                "Value must not have leading whitespace.",
+                None,
+            )
+
+        return schema
+
+    def fix(self, error: EventDetail) -> Dict:
+        value = error.value
+        if not isinstance(value, str):
+            value = str(value)
+        value = value.lstrip()
+        error.schema[error.key] = value
+        return error.schema


### PR DESCRIPTION
As it stands, guardrails is parsing the unidiff as just a string. The validators are written over a list of lines, and perform a lot of bug-prone validation logic.

A better approach would be to use guardrails to parse it into a nested data structure off the bat – this alleviates a lot of the heavy lifting currently done by the validation code, and makes whatever validation is still necessary a lot easier and neater to write.

However, my own testing reveals that this approach does not work well zero-shot (see the commited `.diff.patch` files in the `resources` folder of this PR). In a few-shot context, with some good examples, it achieves better performance. 

This feature is therefore blocked by https://github.com/ShreyaR/guardrails/issues/85.