### PR TITLE
Automatically serialize a PR plan from string to PullRequestDescription

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,24 +42,34 @@ Example:
 ```python
 >>> autopr/services/planner_service/my_planner_service.py
 
+from typing import Union
+from git.repo import Repo
 from autopr.services.planner_service import PlannerServiceBase
 from autopr.models.artifacts import Issue
-from git.repo import Repo
-from autopr.models.rail_objects import PullRequestDescription, CommitPlan
+from autopr.models.rail_objects import PullRequestDescription
 
 
 class MyPlannerService(PlannerServiceBase):
     id = "my-planner"
 
-    def _plan_pr(self, issue: Issue, repo: Repo) -> PullRequestDescription:
-        commits: list[CommitPlan] = []
-        ...
-        return PullRequestDescription(
-            title="My PR title",
-            body="My PR body",
-            commits=commits,
-        )
-``` 
+    def _plan_pr(self, issue: Issue, repo: Repo) -> Union[str, PullRequestDescription]:
+        return """
+Title: My PR title
+Body: My PR body
+Commits:
+  1. Title: My commit title
+     Files:
+       - path/to/file.py
+       - path/to/another/file.py
+  2. Title: My second commit title
+     Files:
+       - path/to/file.py
+       - path/to/another/file.py
+"""
+```
+
+The plan can be returned as a `PullRequestDescription` object or as a string, as shown in the dummy example above.
+If it is returned as a string, it will automatically be parsed into a `PullRequestDescription` object with guardrails.
 
 
 ### Adding a new code generator
@@ -86,18 +96,18 @@ class MyCodegenService(CodegenServiceBase):
         pr_desc: PullRequestDescription,
         current_commit: CommitPlan,
     ) -> DiffStr:    
-        example_diff = """
+        return """
 --- /dev/null
 +++ dummy.py
 @@ -0,0 +1,2 @@
 +def dummy():
 +    pass
 """
-        ...
-        return example_diff
 ```
 
-To use it, set `codegen_id` to `my-codegen` in the AutoPR workflow yml.
+The output of the code generator is a string, which must be a valid patch as applicable by GNU `patch`.
+We're currently working on a serializable patch format similar to the planner service's `PullRequestDescription` object.
+If you're interested in this, please join our [Discord](https://discord.gg/ykk7Znt3K6).
 
 ## How guardrails is used in AutoPR
 

--- a/autopr/models/prompt_rails.py
+++ b/autopr/models/prompt_rails.py
@@ -35,23 +35,6 @@ class PromptRail(pydantic.BaseModel):
                 return True
         return False
 
-    @classmethod
-    def get_rail_spec(cls):
-        return f"""
-<rail version="0.1">
-<output>
-{cls.output_type.rail_spec}
-</output>
-<prompt>
-```
-{{{{raw_response}}}}
-```
-
-@complete_json_suffix_v2
-</prompt>
-</rail>
-"""
-
 
 class InitialFileSelect(PromptRail):
     # Select files given issue and files in repo
@@ -84,25 +67,6 @@ If looking at files would be a waste of time with regard to the issue, let me kn
             ]),
             'token_limit': str(self.token_limit),
         }
-
-    @classmethod
-    def get_rail_spec(cls):
-        return f"""
-<rail version="0.1">
-<output>
-{cls.output_type.rail_spec}
-</output>
-<prompt>
-```
-{{{{raw_response}}}}
-```
-
-If looking at files would be a waste of time, please submit an empty list.
-
-@complete_json_suffix_v2
-</prompt>
-</rail>
-"""
 
 
 class LookAtFiles(PromptRail):
@@ -153,25 +117,6 @@ If looking at files would be a waste of time with regard to the issue, let me kn
 
     def trim_params(self) -> bool:
         return trim_chunk(self.selected_file_contents)
-
-    @classmethod
-    def get_rail_spec(cls):
-        return f"""
-<rail version="0.1">
-<output>
-{cls.output_type.rail_spec}
-</output>
-<prompt>
-```
-{{{{raw_response}}}}
-```
-
-If looking at more files would be a waste of time, please submit an empty list.
-
-@complete_json_suffix_v2
-</prompt>
-</rail>
-"""
 
 
 class ContinueLookingAtFiles(PromptRail):

--- a/autopr/models/prompt_rails.py
+++ b/autopr/models/prompt_rails.py
@@ -14,7 +14,7 @@ from autopr.utils.repo import FileDescriptor, filter_seen_chunks, trim_chunk
 log = structlog.get_logger()
 
 
-class Rail(pydantic.BaseModel):
+class PromptRail(pydantic.BaseModel):
     prompt_spec: ClassVar[str] = ''
     extra_params: ClassVar[dict[str, Any]] = {}
     output_type: ClassVar[typing.Type[RailObject]]
@@ -53,7 +53,7 @@ class Rail(pydantic.BaseModel):
 """
 
 
-class InitialFileSelectRail(Rail):
+class InitialFileSelect(PromptRail):
     # Select files given issue and files in repo
     prompt_spec = f"""Hey, somebody just opened an issue in my repo, could you help me write a pull request?
 
@@ -105,7 +105,7 @@ If looking at files would be a waste of time, please submit an empty list.
 """
 
 
-class LookAtFiles(Rail):
+class LookAtFiles(PromptRail):
     # Select files given issue, unseen files in repo, and notes
     prompt_spec = f"""Hey, somebody just submitted an issue, could you own it, and write a pull request?
 
@@ -174,7 +174,7 @@ If looking at more files would be a waste of time, please submit an empty list.
 """
 
 
-class ContinueLookingAtFiles(Rail):
+class ContinueLookingAtFiles(PromptRail):
     # Continue selecting files and generating fp_notes given issue, unseen files in repo, and notes
     prompt_spec = f"""Hey, somebody just submitted an issue, could you own it, and write a pull request?
 
@@ -228,7 +228,7 @@ Also, let me know if we should take a look at any other files – our budget is 
         return trim_chunk(self.selected_file_contents)
 
 
-class ProposePullRequest(Rail):
+class ProposePullRequest(PromptRail):
     # Generate proposed list of commit messages, given notes and issue
     prompt_spec = f"""Hey somebody just submitted an issue, could you own it, write some commits, and a pull request?
 
@@ -249,7 +249,7 @@ When you're done, send me the pull request title, body, and a list of commits co
     issue: str
 
 
-class NewDiff(Rail):
+class NewDiff(PromptRail):
     # Generate code for a commit, given an issue, a pull request, and a codebase
     prompt_spec = f"""Hey, now that we've got a plan, let's write some code.
 
@@ -293,4 +293,4 @@ Only write a unidiff in the codebase subset we're looking at."""
         return trim_chunk(self.selected_file_contents)
 
 
-RailUnion: TypeAlias = Union[tuple(Rail.__subclasses__())]  # type: ignore
+PromptRailUnion: TypeAlias = Union[tuple(PromptRail.__subclasses__())]  # type: ignore

--- a/autopr/models/rail_objects.py
+++ b/autopr/models/rail_objects.py
@@ -1,4 +1,5 @@
-from typing import List, ClassVar, Optional
+from typing import List, ClassVar, Optional, Union
+from typing_extensions import TypeAlias
 
 import pydantic
 
@@ -6,11 +7,28 @@ from autopr.models.artifacts import DiffStr
 
 
 class RailObject(pydantic.BaseModel):
-    rail_spec: ClassVar[str]
+    output_spec: ClassVar[str]
+
+    @classmethod
+    def get_rail_spec(cls):
+        return f"""
+<rail version="0.1">
+<output>
+{cls.output_spec}
+</output>
+<prompt>
+```
+{{{{raw_document}}}}
+```
+
+@complete_json_suffix_v2
+</prompt>
+</rail>
+"""
 
 
 class InitialFileSelectResponse(RailObject):
-    rail_spec = """<list name="filepaths">
+    output_spec = """<list name="filepaths">
     <string
         description="Files in this repository that we should look at."
         format="filepath"
@@ -20,9 +38,28 @@ class InitialFileSelectResponse(RailObject):
 
     filepaths: List[str]
 
+    @classmethod
+    def get_rail_spec(cls):
+        return f"""
+<rail version="0.1">
+<output>
+{cls.output_spec}
+</output>
+<prompt>
+```
+{{{{raw_document}}}}
+```
+
+If looking at files would be a waste of time, please submit an empty list.
+
+@complete_json_suffix_v2
+</prompt>
+</rail>
+"""
+
 
 class LookAtFilesResponse(RailObject):
-    rail_spec = """<string 
+    output_spec = """<string 
     name="notes" 
     description="Notes relevant to solving the issue, that we will use to plan our code commits." 
     length="1 1000"
@@ -39,9 +76,28 @@ class LookAtFilesResponse(RailObject):
     filepaths_we_should_look_at: Optional[List[str]] = None
     notes: str
 
+    @classmethod
+    def get_rail_spec(cls):
+        return f"""
+<rail version="0.1">
+<output>
+{cls.output_spec}
+</output>
+<prompt>
+```
+{{{{raw_document}}}}
+```
+
+If looking at files would be a waste of time, please submit an empty list.
+
+@complete_json_suffix_v2
+</prompt>
+</rail>
+"""
+
 
 class Diff(RailObject):
-    rail_spec = """<string
+    output_spec = """<string
     name="diff"
     description="The diff of the commit, in unified format (unidiff), as output by `diff -u`. Changes shown in hunk format, with headers akin to `--- filename\n+++ filename\n@@ .,. @@`."
     required="false"
@@ -53,7 +109,7 @@ class Diff(RailObject):
 
 class Commit(RailObject):
     # TODO use this instead of Diff, to get a message describing the changes
-    rail_spec = f"""{Diff.rail_spec}
+    output_spec = f"""{Diff.output_spec}
 <string
     name="message"
     description="The commit message, describing the changes."
@@ -67,7 +123,7 @@ class Commit(RailObject):
 
 
 class FileHunk(RailObject):
-    rail_spec = """<string
+    output_spec = """<string
     name="filepath"
     description="The path to the file we are looking at."
     format="filepath"
@@ -94,7 +150,7 @@ class FileHunk(RailObject):
 
 
 class CommitPlan(RailObject):
-    rail_spec = f"""<string
+    output_spec = f"""<string
     name="commit_message"
     description="The commit message, concisely describing the changes made."
     length="1 100"
@@ -125,7 +181,7 @@ class CommitPlan(RailObject):
 
 
 class PullRequestDescription(RailObject):
-    rail_spec = f"""<string 
+    output_spec = f"""<string 
     name="title" 
     description="The title of the pull request."
 />
@@ -139,7 +195,7 @@ class PullRequestDescription(RailObject):
     description="The commits that will be made in this pull request. Commits must change the code in the repository, and must not be empty."
 >
 <object>
-{CommitPlan.rail_spec}
+{CommitPlan.output_spec}
 </object>
 </list>"""
 
@@ -160,3 +216,6 @@ class PullRequestDescription(RailObject):
                 f"{changes_prefix}{changes_prefix.join(commit_plan.commit_changes_description.splitlines())}\n"
             )
         return pr_text_description
+
+
+RailObjectUnion: TypeAlias = Union[tuple(RailObject.__subclasses__())]  # type: ignore

--- a/autopr/services/codegen_service/base.py
+++ b/autopr/services/codegen_service/base.py
@@ -4,7 +4,7 @@ from git.repo import Repo
 
 from autopr.models.artifacts import DiffStr, Issue
 from autopr.models.rail_objects import PullRequestDescription, CommitPlan
-from autopr.models.rails import FileDescriptor
+from autopr.models.prompt_rails import FileDescriptor
 from autopr.services.diff_service import DiffService
 from autopr.services.rail_service import RailService
 

--- a/autopr/services/codegen_service/rail_v1.py
+++ b/autopr/services/codegen_service/rail_v1.py
@@ -4,7 +4,7 @@ from git.repo import Repo
 
 from autopr.models.artifacts import DiffStr, Issue
 from autopr.models.rail_objects import PullRequestDescription, CommitPlan, Diff
-from autopr.models.rails import NewDiff, FileDescriptor
+from autopr.models.prompt_rails import NewDiff, FileDescriptor
 from autopr.services.codegen_service import CodegenServiceBase
 
 import structlog
@@ -77,7 +77,7 @@ class RailCodegenService(CodegenServiceBase):
             selected_file_contents=files_subset,
             commit=commit_description,
         )
-        patch = self.rail_service.run_rail(rail)
+        patch = self.rail_service.run_prompt_rail(rail)
         if patch is None or not isinstance(patch, Diff):
             raise ValueError('Error generating patch')
         patch_text = patch.diff or ''
@@ -115,7 +115,7 @@ class RailCodegenService(CodegenServiceBase):
                 selected_file_contents=not_looked_at_files,
                 commit=commit_description,
             )
-            patch = self.rail_service.run_rail(rail)
+            patch = self.rail_service.run_prompt_rail(rail)
             if patch is None or not isinstance(patch, Diff):
                 raise ValueError('Error generating patch')
             patch_text += patch.diff or ''

--- a/autopr/services/generation_service.py
+++ b/autopr/services/generation_service.py
@@ -9,7 +9,7 @@ from git import Tree
 from autopr.models.artifacts import Issue
 from autopr.models.rail_objects import PullRequestDescription, InitialFileSelectResponse, LookAtFilesResponse, \
     Diff, CommitPlan
-from autopr.models.rails import InitialFileSelectRail, ContinueLookingAtFiles, LookAtFiles, ProposePullRequest, \
+from autopr.models.prompt_rails import InitialFileSelect, ContinueLookingAtFiles, LookAtFiles, ProposePullRequest, \
     NewDiff, FileDescriptor
 from autopr.services.codegen_service import CodegenService
 from autopr.services.commit_service import CommitService

--- a/autopr/services/planner_service/base.py
+++ b/autopr/services/planner_service/base.py
@@ -4,7 +4,7 @@ from git.repo import Repo
 
 from autopr.models.artifacts import Issue
 from autopr.models.rail_objects import PullRequestDescription
-from autopr.models.rails import FileDescriptor
+from autopr.models.prompt_rails import FileDescriptor
 from autopr.services.rail_service import RailService
 
 import structlog

--- a/autopr/services/planner_service/base.py
+++ b/autopr/services/planner_service/base.py
@@ -1,4 +1,4 @@
-from typing import ClassVar
+from typing import ClassVar, Union
 
 from git.repo import Repo
 
@@ -32,6 +32,14 @@ class PlannerServiceBase:
     ) -> PullRequestDescription:
         self.log.info("Planning PR", issue=issue)
         pr_desc = self._plan_pr(repo, issue)
+        if isinstance(pr_desc, str):
+            self.log.info("Running raw PR description through PullRequestDescription rail", issue=issue, pull_request_string=pr_desc)
+            pr_desc = self.rail_service.run_rail_object(
+                PullRequestDescription,
+                pr_desc
+            )
+            if pr_desc is None:
+                raise ValueError("Failed to parse PR description")
         self.log.info("Planned PR", issue=issue, pull_request=pr_desc)
         return pr_desc
 
@@ -39,5 +47,5 @@ class PlannerServiceBase:
         self,
         repo: Repo,
         issue: Issue,
-    ) -> PullRequestDescription:
+    ) -> Union[str, PullRequestDescription]:
         raise NotImplementedError

--- a/autopr/tests/test_rail_specs.py
+++ b/autopr/tests/test_rail_specs.py
@@ -3,12 +3,12 @@ import typing
 import pytest
 import guardrails as gr
 
-from autopr.models.prompt_rails import PromptRailUnion
+from autopr.models.rail_objects import RailObjectUnion
 
 
 @pytest.mark.parametrize(
     "rail_type",
-    typing.get_args(PromptRailUnion)
+    typing.get_args(RailObjectUnion)
 )
 def test_guardrails_spec_validity(rail_type):
     """Test that all guardrails specs are valid."""

--- a/autopr/tests/test_rail_specs.py
+++ b/autopr/tests/test_rail_specs.py
@@ -3,12 +3,12 @@ import typing
 import pytest
 import guardrails as gr
 
-from autopr.models.rails import RailUnion
+from autopr.models.prompt_rails import PromptRailUnion
 
 
 @pytest.mark.parametrize(
     "rail_type",
-    typing.get_args(RailUnion)
+    typing.get_args(PromptRailUnion)
 )
 def test_guardrails_spec_validity(rail_type):
     """Test that all guardrails specs are valid."""


### PR DESCRIPTION
This PR enables `planner_service` subclasses to return a string – it will automatically be parsed into a `PullRequestService` before being passed along to codegen.

Achieved by refactoring rail service