### PR TITLE
Add manual PR creation workflow and refactor common functionality

### DIFF
--- a/.github/workflows/common-pr-from-issue.yml
+++ b/.github/workflows/common-pr-from-issue.yml
@@ -1,0 +1,27 @@
+name: Common PR From Issue
+on: workflow_call
+inputs:
+  github_token:
+    required: true
+  issue_number:
+    required: true
+  issue_title:
+    required: true
+  issue_body:
+    required: true
+  base_branch:
+    required: true
+jobs:
+  create_pr_from_issue:
+    runs-on: ubuntu-latest
+    steps:
+    - name: AutoPR
+      uses: ./
+      with:
+        github_token: ${{ inputs.github_token }}
+        issue_number: ${{ inputs.issue_number }}
+        issue_title: ${{ inputs.issue_title }}
+        issue_body: ${{ inputs.issue_body }}
+        base_branch: ${{ inputs.base_branch }}
+
+index 5c5f5a8..1e51637 100644

--- a/.github/workflows/create-pr-from-issue.yml
+++ b/.github/workflows/create-pr-from-issue.yml
@@ -29,19 +29,11 @@ jobs:
       with:
         ref: main
         fetch-depth: 1
-    - name: AutoPR
-      uses: ./
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        openai_api_key: ${{ secrets.OPENAI_API_KEY }}
-        issue_number: ${{ github.event.issue.number }}
-        issue_title: ${{ github.event.issue.title }}
-        issue_body: ${{ github.event.issue.body }}
-        codegen_id: rail-v1
-        planner_id: rail-v1
-        base_branch: main
-        model: gpt-4
-        context_limit: 8192
-        min_tokens: 1000
-        max_tokens: 2000
-        num_reasks: 2
+        - name: Call Common PR From Issue
+          uses: ./.github/workflows/common-pr-from-issue.yml
+          with:
+            github_token: ${{ secrets.GITHUB_TOKEN }}
+            issue_number: ${{ github.event.issue.number }}
+            issue_title: ${{ github.event.issue.title }}
+            issue_body: ${{ github.event.issue.body }}
+            base_branch: main

--- a/.github/workflows/manual-pr-from-issue.yml
+++ b/.github/workflows/manual-pr-from-issue.yml
@@ -1,0 +1,21 @@
+name: Manual PR from Issue
+
+on:
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: 'Issue number to create PR from'
+        required: true
+
+jobs:
+  create_pr:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Call Common PR from Issue
+      uses: ./.github/workflows/common-pr-from-issue.yml
+      with:
+        issue_number: ${{ github.event.inputs.issue_number }}
+        pr_title_prefix: '[MANUAL] '
+        pr_body_prefix: ':warning: This PR has been created manually, using the provided issue data. :warning:
+
+'


### PR DESCRIPTION
This PR addresses issue #23 by adding the option for manually running the workflow action from an issue. It also refactors common functionality between the existing create-pr-from-issue workflow and the new manual-pr-from-issue workflow into a separate callable workflow.