### PR TITLE
create-pr-from-issue: Trigger on label instead of 🚀 comment

### DIFF
--- a/.github/workflows/create-pr-from-issue.yml
+++ b/.github/workflows/create-pr-from-issue.yml
@@ -1,8 +1,6 @@
 on:
   issues:
-    types: [opened]
-  issue_comment:
-    types: [created]
+    types: [labeled]
 
 permissions:
   contents: write
@@ -11,42 +9,22 @@ permissions:
 
 jobs:
   autopr:
-    if: ${{ !github.event.issue.pull_request }}
+    if: ${{ contains( github.event.label.name, 'AutoPR') }}
     runs-on: ubuntu-latest
     steps:
     - name: Install jq
       run: sudo apt-get install jq
-    - name: Check if issue or issue comment is created by collaborator
+    - name: Check if label was added by a collaborator
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        username=""
-        if [ "${{ github.event_name }}" == "issues" ]; then
-          username=${{ github.event.issue.user.login }}
-        elif [ "${{ github.event_name }}" == "issue_comment" ]; then
-          username=${{ github.event.comment.user.login }}
-        fi
-
         is_collaborator=$(curl -s -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" \
-          "https://api.github.com/repos/${{ github.repository }}/collaborators/$username" | jq -r '.message')
+          "https://api.github.com/repos/${{ github.repository }}/collaborators/${{ github.event.sender.login }}" | jq -r '.message')
 
         if [ "$is_collaborator" == "Not Found" ]; then
-          echo "Not triggered by a collaborator. Skipping action."
+          echo "Label not added by a collaborator. Skipping action."
           exit 78
         fi
-    - uses: irgolic/pull-request-comment-trigger@master
-      name: Check if AutoPR is triggered
-      id: check
-      with:
-        trigger: '🚀'
-        reaction: rocket
-      env:
-        GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-    - name: Stop if AutoPR is not requested
-      if: steps.check.outputs.triggered == 'false'
-      run: |
-        echo "Issue comment did not include 🚀. Skipping action."
-        exit 78
     - name: Checkout
       uses: actions/checkout@v2
       with:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Built with [Guardrails](https://github.com/ShreyaR/guardrails).
 
 ## 💪 How does it work?
 
-The action triggers when a collaborator uses `🚀` in an issue.
+The action triggers when a collaborator adds an "AutoPR" label to an issue.
 
 1. We ask the model what files in the repo are relevant to the issue
 2. We iteratively show it files, and ask it to write down notes about them


### PR DESCRIPTION
Specifically, trigger whenever a label containing "AutoPR" is added to an issue.

Resolves #35 