### PR TITLE
Expect codegen service to make file changes instead of generating a diff

### DIFF
--- a/autopr/agents/codegen_agent/autonomous_v1/agent.py
+++ b/autopr/agents/codegen_agent/autonomous_v1/agent.py
@@ -32,7 +32,8 @@ class AutonomousCodegenAgent(CodegenAgentBase):
         self.context_size = context_size
         self.iterations_per_commit = iterations_per_commit
 
-    def _split_into_lines(self, text: str) -> list[str]:
+    @staticmethod
+    def _split_into_lines(text: str) -> list[str]:
         lines = text.splitlines()
         # If text ends with a newline, we want to keep that as a line
         if text.rstrip() != text:

--- a/autopr/agents/codegen_agent/base.py
+++ b/autopr/agents/codegen_agent/base.py
@@ -32,23 +32,22 @@ class CodegenAgentBase:
         if kwargs:
             self.log.warning("Codegen did not use additional options", kwargs=kwargs)
 
-    def generate_patch(
+    def generate_changes(
         self,
         repo: Repo,
         issue: Issue,
         pr_desc: PullRequestDescription,
         current_commit: CommitPlan,
-    ) -> DiffStr:
-        self.log.info("Generating patch", issue=issue)
-        patch = self._generate_patch(repo, issue, pr_desc, current_commit)
-        self.log.info("Generated patch", issue=issue, patch=patch)
-        return patch
+    ) -> None:
+        self.log.info("Generating changes", issue=issue)
+        self._generate_changes(repo, issue, pr_desc, current_commit)
+        self.log.info("Generated changes", issue=issue)
 
-    def _generate_patch(
+    def _generate_changes(
         self,
         repo: Repo,
         issue: Issue,
         pr_desc: PullRequestDescription,
         current_commit: CommitPlan,
-    ) -> DiffStr:
+    ) -> None:
         raise NotImplementedError

--- a/autopr/agents/codegen_agent/rail_v1.py
+++ b/autopr/agents/codegen_agent/rail_v1.py
@@ -98,13 +98,13 @@ class RailCodegenAgent(CodegenAgentBase):
         self.file_context_token_limit = file_context_token_limit
         self.file_chunk_size = file_chunk_size
 
-    def _generate_patch(
+    def _generate_changes(
         self,
         repo: Repo,
         issue: Issue,
         pr_desc: PullRequestDescription,
         current_commit: CommitPlan,
-    ) -> DiffStr:
+    ) -> None:
         # Get files
         files = repo_to_file_descriptors(repo, self.file_context_token_limit, self.file_chunk_size)
 
@@ -182,4 +182,5 @@ class RailCodegenAgent(CodegenAgentBase):
             patch_text += patch.diff or ''
             update_not_looked_at_files()
 
-        return patch_text
+        # Apply patch
+        self.diff_service.apply_diff(patch_text)

--- a/autopr/main.py
+++ b/autopr/main.py
@@ -117,7 +117,6 @@ def main(
         extra_params=settings.pull_request_agent_config,
     )
     commit_service = CommitService(
-        diff_service=diff_service,
         repo=repo,
         repo_path=repo_path,
         branch_name=branch_name,

--- a/autopr/services/generation_service.py
+++ b/autopr/services/generation_service.py
@@ -45,16 +45,16 @@ class GenerationService:
 
         is_published = False
         for current_commit in pr_desc.commits:
-            # Generate the patch
-            diff = self.codegen_agent.generate_patch(
+            # Generate the changes
+            self.codegen_agent.generate_changes(
                 repo,
                 issue,
                 pr_desc,
                 current_commit
             )
 
-            # Apply the patch and commit the changes
-            self.commit_service.commit(current_commit, diff)
+            # Commit the changes
+            self.commit_service.commit(current_commit)
 
             # Publish the PR after the first commit is written
             if not is_published:


### PR DESCRIPTION
- generate_patch => generate_changes
- Make rail_v1 apply the diff it writes
- Remove diff_service from CommitService

But really the reason I'm making this change is because I can't figure out why [the diff generated by `git diff` is being called corrupted by `git apply`](https://github.com/irgolic/AutoPR/actions/runs/4671600035/jobs/8272786705#step:5:4192). Can't even reproduce it locally. Might as well cut out the unnecessary `changes => diff => changes` step.