### PR TITLE
fix: strip dotgit to repo url

### DIFF
--- a/autopr/main.py
+++ b/autopr/main.py
@@ -73,7 +73,7 @@ def main(
 
     # Get repo owner and name from remote URL
     remote_url = repo.remotes.origin.url
-    owner, repo_name = remote_url.split('/')[-2:]
+    owner, repo_name = remote_url.rstrip(".git").split('/')[-2:]
 
     # Create completions repo
     completions_repo = get_completions_repo(

--- a/autopr/main.py
+++ b/autopr/main.py
@@ -73,7 +73,7 @@ def main(
 
     # Get repo owner and name from remote URL
     remote_url = repo.remotes.origin.url
-    owner, repo_name = remote_url.rstrip(".git").split('/')[-2:]
+    owner, repo_name = remote_url.removesuffix(".git").split('/')[-2:]
 
     # Create completions repo
     completions_repo = get_completions_repo(


### PR DESCRIPTION
# Why

I use a slightly different mechanism to access the repos. Instead of doing 

```
repo = Repo(dir)
```

I do 

```
    repo = Repo.clone_from(repo_url)
```

This adds a .git to the end of the repo name, and then fails all the API calls which should not be made with the `.git` url (such as https://github.com/irgolic/AutoPR/blob/57186dc5b1515b7e8ab6fe5c6f3908933f5bfc55/autopr/services/publish_service.py#L39-L48)

# How 

Stripping the `.git` works. We could also swap the raw API calls with more use of the GitPython library, but it's a slightly larger change.