### PR TITLE
Refactor events to IssueLabeledEvent

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,8 @@ from git.repo import Repo
 from autopr.agents.pull_request_agent import PullRequestAgentBase
 from autopr.models.artifacts import Issue
 from autopr.models.rail_objects import PullRequestDescription
-from autopr.models.events import IssueOpenedEvent, IssueCommentEvent
+from autopr.models.events import EventUnion
+
 
 
 class MyPullRequestAgent(PullRequestAgentBase):
@@ -59,7 +60,7 @@ class MyPullRequestAgent(PullRequestAgentBase):
         self, 
         issue: Issue, 
         repo: Repo,
-        event: Union[IssueOpenedEvent, IssueCommentEvent],
+        event: EventUnion,
     ) -> Union[str, PullRequestDescription]:
         return """
 Title: My PR title

--- a/autopr/agents/pull_request_agent/base.py
+++ b/autopr/agents/pull_request_agent/base.py
@@ -3,7 +3,7 @@ from typing import ClassVar, Union
 from git.repo import Repo
 
 from autopr.models.artifacts import Issue
-from autopr.models.events import IssueCommentEvent, IssueOpenedEvent
+from autopr.models.events import EventUnion
 from autopr.models.rail_objects import PullRequestDescription
 from autopr.services.chain_service import ChainService
 from autopr.services.rail_service import RailService
@@ -32,7 +32,7 @@ class PullRequestAgentBase:
         self,
         repo: Repo,
         issue: Issue,
-        event: Union[IssueOpenedEvent, IssueCommentEvent],
+        event: EventUnion,
     ) -> PullRequestDescription:
         log = self.log.bind(issue_number=issue.number,
                             event_type=event.event_type)
@@ -53,6 +53,6 @@ class PullRequestAgentBase:
         self,
         repo: Repo,
         issue: Issue,
-        event: Union[IssueOpenedEvent, IssueCommentEvent],
+        event: EventUnion
     ) -> Union[str, PullRequestDescription]:
         raise NotImplementedError

--- a/autopr/agents/pull_request_agent/rail_v1.py
+++ b/autopr/agents/pull_request_agent/rail_v1.py
@@ -4,11 +4,11 @@ import pydantic
 from git.repo import Repo
 
 from autopr.models.artifacts import Issue
+from autopr.models.events import EventUnion
 from autopr.models.rail_objects import PullRequestDescription, RailObject
 from autopr.models.prompt_rails import PromptRail
 from .base import PullRequestAgentBase
 from autopr.utils.repo import repo_to_file_descriptors, trim_chunk, filter_seen_chunks, FileDescriptor
-from ...models.events import IssueOpenedEvent, IssueCommentEvent
 
 
 class InitialFileSelectResponse(RailObject):
@@ -361,7 +361,7 @@ class RailPullRequestAgent(PullRequestAgentBase):
         self,
         repo: Repo,
         issue: Issue,
-        event: Union[IssueOpenedEvent, IssueCommentEvent],
+        event: EventUnion,
     ) -> Union[str, PullRequestDescription]:
         # Get files
         files = repo_to_file_descriptors(repo, self.file_context_token_limit, self.file_chunk_size)

--- a/autopr/gh_actions_entrypoint.py
+++ b/autopr/gh_actions_entrypoint.py
@@ -5,6 +5,7 @@ from autopr.main import main, Settings
 import yaml
 
 from autopr.log_config import configure_logging
+from autopr.services.event_service import GithubEventService
 
 configure_logging()
 

--- a/autopr/models/events.py
+++ b/autopr/models/events.py
@@ -9,17 +9,13 @@ class Event(pydantic.BaseModel):
     event_type: str
 
 
-class IssueOpenedEvent(Event):
+class IssueLabeledEvent(Event):
     event_type: Literal['issue_opened'] = 'issue_opened'
 
     issue: Issue
+    label: str
 
 
-class IssueCommentEvent(Event):
-    event_type: Literal['issue_closed'] = 'issue_closed'
+# TODO implement more event types (i.e., code review)
 
-    issue: Issue
-    new_comment: Message
-
-
-EventUnion = Union[tuple(Event.__subclasses__())]  # type: ignore
+EventUnion = IssueLabeledEvent

--- a/autopr/services/generation_service.py
+++ b/autopr/services/generation_service.py
@@ -11,7 +11,7 @@ from ..agents.pull_request_agent import PullRequestAgent
 
 import structlog
 
-from ..models.events import IssueCommentEvent, IssueOpenedEvent
+from ..models.events import EventUnion
 
 log = structlog.get_logger()
 
@@ -35,7 +35,7 @@ class GenerationService:
         self,
         repo: Repo,
         issue: Issue,
-        event: Union[IssueOpenedEvent, IssueCommentEvent]
+        event: EventUnion,
     ) -> None:
         # Switch to the base branch
         self.commit_service.overwrite_new_branch()


### PR DESCRIPTION
IssueOpened and IssueCommentAdded events were leftover from before using labels to trigger AutoPR.
Fixes the bug wherein only the first issue comment is used as context.