### PR TITLE
Improve code documentation

### DIFF
--- a/autopr/agents/brain_agent/base.py
+++ b/autopr/agents/brain_agent/base.py
@@ -18,6 +18,12 @@ import structlog
 
 
 class BrainAgentBase:
+    """
+    Base class for Brain agents.
+    The Brain is responsible for orchestrating the entire process of generating a pull request by invoking sub-agents.
+    """
+
+    #: The ID of the agent, used to identify it in the settings. Set it in the subclass.
     id: ClassVar[str]
 
     def __init__(
@@ -69,4 +75,8 @@ class BrainAgentBase:
         self,
         event: EventUnion,
     ) -> None:
+        """
+        Override this method to implement your own logic of the Brain agent.
+        This method should orchestrate the entire process of generating a pull request.
+        """
         raise NotImplementedError

--- a/autopr/agents/brain_agent/simple_v1.py
+++ b/autopr/agents/brain_agent/simple_v1.py
@@ -8,6 +8,13 @@ log = structlog.get_logger()
 
 
 class BasicBrainAgent(BrainAgentBase):
+    """
+    A simple Brain agent that:
+    - Plans a pull request
+    - Implements each commit in the pull request
+    """
+
+    #: The ID of the agent, used to identify it in the settings
     id = "simple-v1"
 
     def _generate_pr(

--- a/autopr/agents/codegen_agent/autonomous_v1/agent.py
+++ b/autopr/agents/codegen_agent/autonomous_v1/agent.py
@@ -21,6 +21,24 @@ from autopr.services.rail_service import RailService
 
 
 class AutonomousCodegenAgent(CodegenAgentBase):
+    """
+    Iteratively change the codebase given a CommitPlan.
+    This agent iterates up to `iterations_per_commit` times, each time picking one of the following actions:
+    - Add a new file
+    - Edit a code hunk (specified as line range)
+    - Finish the commit
+
+    The agent will stop when it has iterated `iterations_per_commit` times, or when it has finished the commit.
+
+    Parameters
+    ----------
+
+    context_size: int
+        The number of lines of context to include around each code hunk.
+    iterations_per_commit: int
+        The maximum number of iterations to run for each commit.
+    """
+
     id = "auto-v1"
 
     def __init__(

--- a/autopr/agents/codegen_agent/base.py
+++ b/autopr/agents/codegen_agent/base.py
@@ -13,6 +13,13 @@ import structlog
 
 
 class CodegenAgentBase:
+    """
+    Base class for Codegen agents.
+    Codegen agents are responsible for changing the codebase to implement
+    the changes described in the CommitPlan.
+    """
+
+    #: The ID of the agent, used to identify it in the settings. Set it in the subclass.
     id: ClassVar[str]
 
     def __init__(
@@ -69,4 +76,8 @@ class CodegenAgentBase:
         pr_desc: PullRequestDescription,
         current_commit: CommitPlan,
     ) -> None:
+        """
+        Override this method to implement your own codegen logic.
+        This method should modify the files in the repo to implement the changes described in the CommitPlan.
+        """
         raise NotImplementedError

--- a/autopr/agents/codegen_agent/rail_v1.py
+++ b/autopr/agents/codegen_agent/rail_v1.py
@@ -27,6 +27,7 @@ class Diff(RailObject):
 
 class Commit(RailObject):
     # TODO use this instead of Diff, to get a commit message rewrite
+    #  EDIT: development focus has shifted to the autonomous codegen agent as a better solution
     output_spec = f"""{Diff.output_spec}
 <string
     name="message"
@@ -85,6 +86,25 @@ Only write a unidiff in the codebase subset we're looking at."""
 
 
 class RailCodegenAgent(CodegenAgentBase):
+    """
+    Generate and apply diff given a CommitPlan.
+    It chunkifies the files specified in CommitPlan.relevant_file_hunks,
+    and writes diffs as it goes along looking at the file chunks.
+
+    WARNING: This agent implementation heavily relies on the `unidiff` custom guardrails validator,
+    and it still sometimes produces ambiguous results.
+    If you're interested in continuing experimentation with the diff generation approach,
+    try few-shotting. At time of writing, few-shotting is not implemented in guardrails.
+
+    Parameters
+    ----------
+
+    file_context_token_limit: int
+        The maximum size taken up by the file context (concatenated file chunks) in the prompt.
+
+    file_chunk_size: int
+        The maximum token size of each chunk that a file is split into.
+    """
     id = "rail-v1"
 
     def __init__(
@@ -143,10 +163,13 @@ class RailCodegenAgent(CodegenAgentBase):
             raise ValueError('Error generating patch')
         patch_text = patch.diff or ''
 
-        # if not all chunks were looked at, keep running the rail until all chunks are looked at
+        # If not all chunks were looked at, keep running the rail until all chunks are looked at
         not_looked_at_files = []
 
         def update_not_looked_at_files():
+            """
+            Update the list of files to look at in the next iteration.
+            """
             nonlocal not_looked_at_files
 
             not_looked_at_files = []
@@ -158,6 +181,8 @@ class RailCodegenAgent(CodegenAgentBase):
                 not_looked_at_files.append(f)
 
         update_not_looked_at_files()
+
+        # If there are still files to look at, keep running the rail and generating patches
         reasks = self.rail_service.num_reasks
         while not_looked_at_files and reasks > 0:
             reasks -= 1
@@ -166,10 +191,12 @@ class RailCodegenAgent(CodegenAgentBase):
             for f in not_looked_at_files:
                 log.debug(f' - {f.path} ({f.end_chunk - f.start_chunk} chunks left)')
 
+            # Only look at the files that haven't been looked at yet
             files_subset = [
                 f.copy(deep=True) for f in files_subset
                 if f.end_chunk != len(f.chunks)
             ]
+            # Run NewDiff rail
             rail = NewDiff(
                 issue=issue,
                 pull_request_description=pr_desc,
@@ -179,6 +206,8 @@ class RailCodegenAgent(CodegenAgentBase):
             patch = self.rail_service.run_prompt_rail(rail)
             if patch is None or not isinstance(patch, Diff):
                 raise ValueError('Error generating patch')
+
+            # Concatenate the patch text
             patch_text += patch.diff or ''
             update_not_looked_at_files()
 

--- a/autopr/agents/codegen_agent/rail_v1.py
+++ b/autopr/agents/codegen_agent/rail_v1.py
@@ -105,6 +105,7 @@ class RailCodegenAgent(CodegenAgentBase):
     file_chunk_size: int
         The maximum token size of each chunk that a file is split into.
     """
+
     id = "rail-v1"
 
     def __init__(

--- a/autopr/agents/pull_request_agent/base.py
+++ b/autopr/agents/pull_request_agent/base.py
@@ -13,6 +13,12 @@ import structlog
 
 
 class PullRequestAgentBase:
+    """
+    Base class for Pull Request agents.
+    Pull Request agents are responsible for generating the description of a pull request.
+    """
+
+    #: The ID of the agent, used to identify it in the settings. Set it in the subclass.
     id: ClassVar[str]
 
     def __init__(
@@ -61,4 +67,9 @@ class PullRequestAgentBase:
         issue: Issue,
         event: EventUnion
     ) -> Union[str, PullRequestDescription]:
+        """
+        Override this method to implement your own pull request planning logic.
+        This method should return a PullRequestDescription object, or a string.
+        If a string is returned, it will automatically be parsed into a PullRequestDescription object by guardrails.
+        """
         raise NotImplementedError

--- a/autopr/agents/pull_request_agent/rail_v1.py
+++ b/autopr/agents/pull_request_agent/rail_v1.py
@@ -239,6 +239,21 @@ Folders are created automatically; do not make them in their own commit."""
 
 
 class RailPullRequestAgent(PullRequestAgentBase):
+    """
+    Plan a pull request by iteratively selecting files to look at, taking notes while looking at them,
+    and then generating a list of commits.
+
+    File selection is performed by giving the agent a list of filenames, and asking it to select a subset of them.
+
+    Parameters
+    ----------
+    file_context_token_limit: int
+        The maximum size taken up by the file context (concatenated file chunks) in the prompt.
+
+    file_chunk_size: int
+        The maximum token size of each chunk that a file is split into.
+    """
+
     id = 'rail-v1'
 
     def __init__(

--- a/autopr/models/events.py
+++ b/autopr/models/events.py
@@ -6,16 +6,22 @@ from autopr.models.artifacts import Issue, Message
 
 
 class Event(pydantic.BaseModel):
+    """
+    Events trigger AutoPR to run in different ways.
+
+    TODO implement more event types (i.e., code review)
+    """
     event_type: str
 
 
 class IssueLabeledEvent(Event):
+    """
+    Event triggered when a label is added to an issue.
+    """
     event_type: Literal['issue_opened'] = 'issue_opened'
 
     issue: Issue
     label: str
 
-
-# TODO implement more event types (i.e., code review)
 
 EventUnion = IssueLabeledEvent

--- a/autopr/models/prompt_chains.py
+++ b/autopr/models/prompt_chains.py
@@ -26,6 +26,11 @@ class PromptChain(pydantic.BaseModel):
         return prompt_params
 
     def trim_params(self) -> bool:
+        """
+        Override this method to trim the parameters of the prompt.
+        This is called when the prompt is too long.
+        """
+
         log.warning("Naively trimming params", rail=self)
         prompt_params = dict(self)
         # If there are any lists, remove the last element of the first one you find

--- a/autopr/models/prompt_rails.py
+++ b/autopr/models/prompt_rails.py
@@ -10,12 +10,36 @@ log = structlog.get_logger()
 
 
 class PromptRail(pydantic.BaseModel):
+    """
+    A prompt rail is a pydantic model used to specify a prompt for a guardrails LLM call.
+    See RailObject, RailService, and [Guardrails docs](https://docs.guardrails.io/) for more information.
+
+    To define your own prompt rail:
+    - declare your output type by subclassing RailObject, and referencing it in the `output_type` class variable
+    - write a prompt template in the `prompt_spec` class variable, referencing parameters as {param}
+    - define your parameters as pydantic instance attributes
+
+    Instance attributes declared in the PromptRail are automatically filled into the
+    `prompt_spec` template string, wherever they are referenced as {param}.
+    """
+
+    #: Whether to invoke the guardrails LLM call on the output of an ordinary LLM call, or just by itself.
     two_step: ClassVar[bool] = True
+
+    #: The prompt template to use for the guardrails LLM call (reference string parameters as {param}).
     prompt_spec: ClassVar[str] = ''
+
+    #: Extra parameters to pass to the guardrails LLM call.
     extra_params: ClassVar[dict[str, Any]] = {}
+
+    #: The RailObject type to parse the LLM response into.
     output_type: ClassVar[typing.Type[RailObject]]
 
     def get_string_params(self) -> dict[str, str]:
+        """
+        Get the parameters of the prompt as a dictionary of strings.
+        Override this method to specify your own parameters.
+        """
         prompt_params = {}
         for key, value in self:
             if isinstance(value, list):
@@ -27,6 +51,11 @@ class PromptRail(pydantic.BaseModel):
         return prompt_params
 
     def trim_params(self) -> bool:
+        """
+        This is called when the prompt is too long.
+        Override this method to trim the parameters of the prompt.
+        """
+
         log.warning("Naively trimming params", rail=self)
         prompt_params = dict(self)
         # If there are any lists, remove the last element of the first one you find

--- a/autopr/models/rail_objects.py
+++ b/autopr/models/rail_objects.py
@@ -16,6 +16,7 @@ class RailObject(pydantic.BaseModel):
     - write an XML string compatible with the guardrails XML spec in the `output_spec` class variable
     - define your parameters as pydantic instance attributes
     """
+
     output_spec: ClassVar[str]
 
     @classmethod

--- a/autopr/models/rail_objects.py
+++ b/autopr/models/rail_objects.py
@@ -8,10 +8,23 @@ from autopr.models.artifacts import DiffStr
 
 
 class RailObject(pydantic.BaseModel):
+    """
+    A RailObject is a pydantic model that represents the output of a guardrails call.
+    See PromptRail and RailService, and [Guardrails docs](https://docs.guardrails.io/) for more information.
+
+    To define your own RailObject:
+    - write an XML string compatible with the guardrails XML spec in the `output_spec` class variable
+    - define your parameters as pydantic instance attributes
+    """
     output_spec: ClassVar[str]
 
     @classmethod
     def get_rail_spec(cls):
+        """
+        Get the XML spec template used to define the guardrails output.
+        Should include a `{{raw_document}}` in the prompt section,
+        which will be replaced by the input prompt/two-step LLM output.
+        """
         return f"""
 <rail version="0.1">
 <output>

--- a/autopr/repos/completions_repo.py
+++ b/autopr/repos/completions_repo.py
@@ -9,6 +9,11 @@ from autopr.utils import tokenizer
 
 
 class CompletionsRepo:
+    """
+    Repository that handles running completions through a language model.
+    """
+
+    #: A list of models that this repo implements. Set this in the subclass.
     models: list[str]
 
     def __init__(
@@ -74,6 +79,9 @@ class CompletionsRepo:
         max_tokens: int,
         temperature: float,
     ) -> str:
+        """
+        Subclass this method to implement the language model call.
+        """
         raise NotImplementedError
 
 

--- a/autopr/services/chain_service.py
+++ b/autopr/services/chain_service.py
@@ -42,6 +42,15 @@ class ChatOpenAI(LangChainChatOpenAI):
 
 
 class ChainService:
+    """
+    Service that handles running langchain completions according to a PromptChain subclass.
+
+    This service is responsible for:
+    - compiling the prompt according to `PromptChain.prompt_template` and `PromptChain.get_string_params()`
+    - running the prompt through langchain
+    - parsing the output according to `PromptChain.output_parser`
+    - Keeping `publish_service` informed of what's going on
+    """
     def __init__(
         self,
         completions_repo: CompletionsRepo,

--- a/autopr/services/chain_service.py
+++ b/autopr/services/chain_service.py
@@ -51,6 +51,7 @@ class ChainService:
     - parsing the output according to `PromptChain.output_parser`
     - Keeping `publish_service` informed of what's going on
     """
+
     def __init__(
         self,
         completions_repo: CompletionsRepo,

--- a/autopr/services/commit_service.py
+++ b/autopr/services/commit_service.py
@@ -15,6 +15,7 @@ class CommitService:
 
     Ensures there is always a commit on the branch.
     """
+
     def __init__(
         self,
         repo: Repo,

--- a/autopr/services/commit_service.py
+++ b/autopr/services/commit_service.py
@@ -10,6 +10,11 @@ from autopr.services.diff_service import DiffService
 
 
 class CommitService:
+    """
+    Service for creating branches, committing changes, and calling `git push` on the repository.
+
+    Ensures there is always a commit on the branch.
+    """
     def __init__(
         self,
         repo: Repo,
@@ -22,7 +27,6 @@ class CommitService:
         self.branch_name = branch_name
         self.base_branch_name = base_branch_name
 
-        self.is_published = False
         self._empty_commit = CommitPlan(
             commit_message="[empty]",
         )

--- a/autopr/services/diff_service.py
+++ b/autopr/services/diff_service.py
@@ -10,6 +10,11 @@ log = structlog.get_logger()
 
 
 class DiffService:
+    """
+    Service for getting and applying diffs.
+
+    Diffs are represented as `DiffStr` (a type alias for `str`).
+    """
     def __init__(
         self,
         repo: Repo,

--- a/autopr/services/diff_service.py
+++ b/autopr/services/diff_service.py
@@ -15,6 +15,7 @@ class DiffService:
 
     Diffs are represented as `DiffStr` (a type alias for `str`).
     """
+
     def __init__(
         self,
         repo: Repo,

--- a/autopr/services/event_service.py
+++ b/autopr/services/event_service.py
@@ -14,6 +14,7 @@ class EventService:
     To support other platforms (Gitlab/Bitbucket/Gitea), subclass this and override `parse_event`.
     See irgolic/AutoPR#46 for more details.
     """
+
     def parse_event(self, event_name: str, event: dict[str, Any]) -> EventUnion:
         raise NotImplementedError
 
@@ -26,6 +27,7 @@ class GithubEventService(EventService):
 
     See https://docs.github.com/en/webhooks-and-events/events/issue-event-types
     """
+
     def __init__(
         self,
         github_token: str,

--- a/autopr/services/event_service.py
+++ b/autopr/services/event_service.py
@@ -8,11 +8,24 @@ from autopr.models.events import IssueLabeledEvent, EventUnion
 
 
 class EventService:
+    """
+    Service for parsing events that trigger AutoPR into one of the `EventUnion` types.
+
+    To support other platforms (Gitlab/Bitbucket/Gitea), subclass this and override `parse_event`.
+    See irgolic/AutoPR#46 for more details.
+    """
     def parse_event(self, event_name: str, event: dict[str, Any]) -> EventUnion:
         raise NotImplementedError
 
 
 class GithubEventService(EventService):
+    """
+    Service for parsing GitHub events into one of the `EventUnion` types.
+
+    Currently only supports `IssueLabeledEvent`, which is triggered when a label is added to an issue.
+
+    See https://docs.github.com/en/webhooks-and-events/events/issue-event-types
+    """
     def __init__(
         self,
         github_token: str,
@@ -21,6 +34,9 @@ class GithubEventService(EventService):
         self.log = structlog.get_logger()
 
     def _to_issue_labeled_event(self, event: dict[str, Any]) -> IssueLabeledEvent:
+        """
+        See https://docs.github.com/en/webhooks-and-events/events/issue-event-types#labeled
+        """
         # Get issue comments
         url = event['issue']['comments_url']
         assert url.startswith('https://api.github.com/repos/'), "Unexpected comments_url"

--- a/autopr/services/publish_service.py
+++ b/autopr/services/publish_service.py
@@ -473,3 +473,23 @@ AutoPR encountered an error while trying to fix {issue_link}.
             self.log.error('Failed to get pull requests', response_text=response.text)
 
         return None
+
+
+class DummyPublishService(PublishService):
+    def __init__(self):
+        super().__init__(
+            issue=Issue(
+                number=1,
+                title="Test issue",
+                author="test",
+                messages=[],
+            )
+        )
+
+    def _publish(
+        self,
+        title: str,
+        body: str,
+        success: bool = False,
+    ):
+        pass

--- a/autopr/services/publish_service.py
+++ b/autopr/services/publish_service.py
@@ -35,6 +35,7 @@ class PublishService:
     - `publish_update` to publish a simple textual update
     - `publish_call` to publish a multi-hunk update with a summary and subsections
     """
+
     def __init__(
         self,
         issue: Issue,
@@ -368,6 +369,14 @@ class PublishService:
 
 
 class GithubPublishService(PublishService):
+    """
+    Publishes the PR to Github.
+
+    Sets it as draft while it's being updated, and removes the draft status when it's finalized.
+    Adds a shield linking to the action logs, an"Fixes #{issue_number}" link.
+
+    """
+
     def __init__(
         self,
         issue: Issue,
@@ -547,6 +556,7 @@ AutoPR encountered an error while trying to fix {issue_link}.
         """
         Returns the PR dict of the first open pull request with the same head and base branches
         """
+
         url = f'https://api.github.com/repos/{self.owner}/{self.repo}/pulls'
         headers = self._get_headers()
         params = {'state': 'open', 'head': f'{self.owner}:{self.head_branch}', 'base': self.base_branch}

--- a/autopr/services/rail_service.py
+++ b/autopr/services/rail_service.py
@@ -17,33 +17,6 @@ log = structlog.get_logger()
 
 T = TypeVar('T', bound=RailObject)
 
-# class PromptRail(pydantic.BaseModel):
-#     two_step: ClassVar[bool] = True
-#     prompt_spec: ClassVar[str] = ''
-#     extra_params: ClassVar[dict[str, Any]] = {}
-#     output_type: ClassVar[typing.Type[RailObject]]
-#
-#     def get_string_params(self) -> dict[str, str]:
-#         prompt_params = {}
-#         for key, value in self:
-#             if isinstance(value, list):
-#                 prompt_params[key] = '\n\n'.join(
-#                     [str(item) for item in value]
-#                 )
-#             else:
-#                 prompt_params[key] = str(value)
-#         return prompt_params
-#
-#     def trim_params(self) -> bool:
-#         log.warning("Naively trimming params", rail=self)
-#         prompt_params = dict(self)
-#         # If there are any lists, remove the last element of the first one you find
-#         for key, value in prompt_params.items():
-#             if isinstance(value, list) and len(value) > 0:
-#                 setattr(self, key, value[:-1])
-#                 return True
-#         return False
-
 
 class RailService:
     """
@@ -99,6 +72,7 @@ class RailService:
     rail_system_prompt: str
         System prompt to use for rail guardrails calls
     """
+
     def __init__(
         self,
         completions_repo: CompletionsRepo,


### PR DESCRIPTION
Fixes #34 

Adds docstrings in `agents`, `services`, `repos`, and `models`.