### PR TITLE
Refactor prompt specifications into PromptBase, trim langchain prompts

### DIFF
--- a/autopr/agents/codegen_agent/autonomous_v1/actions.py
+++ b/autopr/agents/codegen_agent/autonomous_v1/actions.py
@@ -122,7 +122,7 @@ class Action(RailObject):
 class MakeDecision(PromptRail):
     two_step = False
     output_type = Action
-    prompt_spec = f"""You are about to make a decision on what to do next.
+    prompt_template = f"""You are about to make a decision on what to do next.
 
 This is the issue that was opened:
 ```{{issue}}```

--- a/autopr/agents/codegen_agent/rail_v1.py
+++ b/autopr/agents/codegen_agent/rail_v1.py
@@ -43,7 +43,7 @@ class Commit(RailObject):
 
 class NewDiff(PromptRail):
     # Generate code for a commit, given an issue, a pull request, and a codebase
-    prompt_spec = f"""Hey, now that we've got a plan, let's write some code.
+    prompt_template = f"""Hey, now that we've got a plan, let's write some code.
 
 This is the issue that was opened:
 ```{{issue}}```

--- a/autopr/agents/codegen_agent/rail_v1.py
+++ b/autopr/agents/codegen_agent/rail_v1.py
@@ -61,9 +61,9 @@ Please implement the commit, and send me the unidiff.
 Only write a unidiff in the codebase subset we're looking at."""
 
     output_type = Diff
-    extra_params = {
-        'temperature': 0.0,
-    }
+    # extra_params = {
+    #     'temperature': 0.0,
+    # }
 
     issue: Issue
     pull_request_description: PullRequestDescription

--- a/autopr/agents/pull_request_agent/rail_v1.py
+++ b/autopr/agents/pull_request_agent/rail_v1.py
@@ -55,9 +55,9 @@ Respond with a very short rationale, and a list of files.
 If looking at files would be a waste of time with regard to the issue, respond with an empty list."""
 
     output_type = InitialFileSelectResponse
-    extra_params = {
-        'temperature': 0,
-    }
+    # extra_params = {
+    #     'temperature': 0,
+    # }
 
     issue: Issue
     file_descriptors: list[FileDescriptor]
@@ -129,9 +129,9 @@ Respond with some very brief notes, and a list of files to continue looking at.
 If looking at files would be a waste of time with regard to the issue, respond with an empty list."""
 
     output_type = LookAtFilesResponse
-    extra_params = {
-        'temperature': 0.2,
-    }
+    # extra_params = {
+    #     'temperature': 0.2,
+    # }
 
     issue: Issue
     selected_file_contents: list[FileDescriptor]
@@ -181,9 +181,9 @@ Take some notes that will help us plan commits and write code to fix the issue.
 Also, let me know if we should take a look at any other files – our budget is {{token_limit}} tokens."""
 
     output_type = LookAtFilesResponse
-    extra_params = {
-        'temperature': 0.2,
-    }
+    # extra_params = {
+    #     'temperature': 0.2,
+    # }
 
     issue: Issue
     notes: str
@@ -230,9 +230,9 @@ Ensure you specify the files relevant to the commit, especially if the commit is
 Folders are created automatically; do not make them in their own commit."""
 
     output_type = PullRequestDescription
-    extra_params = {
-        'temperature': 0.1,
-    }
+    # extra_params = {
+    #     'temperature': 0.1,
+    # }
 
     notes_taken_while_looking_at_files: str
     issue: Issue

--- a/autopr/agents/pull_request_agent/rail_v1.py
+++ b/autopr/agents/pull_request_agent/rail_v1.py
@@ -42,7 +42,7 @@ If looking at files would be a waste of time, please submit an empty list.
 
 class InitialFileSelect(PromptRail):
     # Select files given issue and files in repo
-    prompt_spec = f"""Hey, somebody just opened an issue in my repo, could you help me write a pull request?
+    prompt_template = f"""Hey, somebody just opened an issue in my repo, could you help me write a pull request?
 
 The issue is:
 ```{{issue}}```
@@ -112,7 +112,7 @@ If looking at files would be a waste of time, please submit an empty list.
 
 class LookAtFiles(PromptRail):
     # Select files given issue, unseen files in repo, and notes
-    prompt_spec = f"""Hey, somebody just submitted an issue, could you own it, and write a pull request?
+    prompt_template = f"""Hey, somebody just submitted an issue, could you own it, and write a pull request?
 
 The issue that was opened:
 ```{{issue}}```
@@ -163,7 +163,7 @@ If looking at files would be a waste of time with regard to the issue, respond w
 
 class ContinueLookingAtFiles(PromptRail):
     # Continue selecting files and generating fp_notes given issue, unseen files in repo, and notes
-    prompt_spec = f"""Hey, somebody just submitted an issue, could you own it, and write a pull request?
+    prompt_template = f"""Hey, somebody just submitted an issue, could you own it, and write a pull request?
 
 The issue that was opened:
 ```{{issue}}```
@@ -217,7 +217,7 @@ Also, let me know if we should take a look at any other files – our budget is 
 
 class ProposePullRequest(PromptRail):
     # Generate proposed list of commit messages, given notes and issue
-    prompt_spec = f"""Hey somebody just submitted an issue, could you own it, write some commits, and a pull request?
+    prompt_template = f"""Hey somebody just submitted an issue, could you own it, write some commits, and a pull request?
 
 These are notes we took while looking at the repo:
 ```{{notes_taken_while_looking_at_files}}```

--- a/autopr/main.py
+++ b/autopr/main.py
@@ -91,6 +91,8 @@ def main(
     chain_service = ChainService(
         completions_repo=completions_repo,
         publish_service=publish_service,
+        context_limit=settings.context_limit,
+        min_tokens=settings.min_tokens,
     )
 
     # auto-v1 generates diffs with `git diff`, so use that

--- a/autopr/models/prompt_base.py
+++ b/autopr/models/prompt_base.py
@@ -3,6 +3,8 @@ from typing import ClassVar
 import pydantic
 import structlog
 
+from autopr.utils.tokenizer import get_tokenizer
+
 log = structlog.get_logger()
 
 
@@ -44,6 +46,14 @@ class PromptBase(pydantic.BaseModel):
             else:
                 prompt_params[key] = str(value)
         return prompt_params
+
+    def calculate_prompt_token_length(self) -> int:
+        """
+        Calculate the number of tokens in the prompt message.
+        """
+        tokenizer = get_tokenizer()
+        prompt_message = self.get_prompt_message()
+        return len(tokenizer.encode(prompt_message))
 
     def trim_params(self) -> bool:
         """

--- a/autopr/models/prompt_base.py
+++ b/autopr/models/prompt_base.py
@@ -22,6 +22,14 @@ class PromptBase(pydantic.BaseModel):
     #: Extra parameters to pass to the guardrails LLM call.
     # extra_params: ClassVar[dict[str, Any]] = {}
 
+    def get_prompt_message(self) -> str:
+        """
+        Get the prompt message that is sent the LLM call.
+        """
+        spec = self.prompt_template
+        prompt_params = self.get_string_params()
+        return spec.format(**prompt_params)
+
     def get_string_params(self) -> dict[str, str]:
         """
         Get the parameters of the prompt as a dictionary of strings.

--- a/autopr/models/prompt_base.py
+++ b/autopr/models/prompt_base.py
@@ -1,0 +1,41 @@
+import pydantic
+import structlog
+
+log = structlog.get_logger()
+
+
+class PromptBase(pydantic.BaseModel):
+    """
+    Base class for all prompt specifications.
+    Assumes prompt parameters are specified as pydantic instance attributes.
+    """
+
+    def get_string_params(self) -> dict[str, str]:
+        """
+        Get the parameters of the prompt as a dictionary of strings.
+        Override this method to specify your own parameters.
+        """
+        prompt_params = {}
+        for key, value in self:
+            if isinstance(value, list):
+                prompt_params[key] = '\n\n'.join(
+                    [str(item) for item in value]
+                )
+            else:
+                prompt_params[key] = str(value)
+        return prompt_params
+
+    def trim_params(self) -> bool:
+        """
+        Override this method to trim the parameters of the prompt.
+        This is called when the prompt is too long.
+        """
+
+        log.warning("Naively trimming params", rail=self)
+        prompt_params = dict(self)
+        # If there are any lists, remove the last element of the first one you find
+        for key, value in prompt_params.items():
+            if isinstance(value, list) and len(value) > 0:
+                setattr(self, key, value[:-1])
+                return True
+        return False

--- a/autopr/models/prompt_base.py
+++ b/autopr/models/prompt_base.py
@@ -55,10 +55,27 @@ class PromptBase(pydantic.BaseModel):
         prompt_message = self.get_prompt_message()
         return len(tokenizer.encode(prompt_message))
 
+    def ensure_token_length(self, max_length: int) -> bool:
+        """
+        Ensure that the prompt message is no longer than `max_length` tokens.
+        """
+        # Make sure there are at least `min_tokens` tokens left
+        while max_length < self.calculate_prompt_token_length():
+            # Iteratively rim the params
+            if not self.trim_params():
+                rail_name = self.__class__.__name__
+                log.debug(f'Could not trim params on rail {rail_name}: {self.get_string_params()}')
+                return False
+        return True
+
     def trim_params(self) -> bool:
         """
         Override this method to trim the parameters of the prompt.
-        This is called when the prompt is too long.
+        This is called when the prompt is too long. By default, this method
+        removes the last element of the first list it finds.
+
+        TODO give this method better heuristics for trimming, so it doesn't just
+         get called over and over again.
         """
 
         log.warning("Naively trimming params", rail=self)

--- a/autopr/models/prompt_base.py
+++ b/autopr/models/prompt_base.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 import pydantic
 import structlog
 
@@ -7,8 +9,18 @@ log = structlog.get_logger()
 class PromptBase(pydantic.BaseModel):
     """
     Base class for all prompt specifications.
-    Assumes prompt parameters are specified as pydantic instance attributes.
+
+    Prompt parameters should be specified as pydantic instance attributes.
+    They will be automatically filled into the `prompt_template` string,
+    wherever they are referenced as {param}.
     """
+
+    #: The prompt template to use for the LLM call (reference string parameters as {param}).
+    prompt_template: ClassVar[str] = ''
+
+    # TODO implement extra_params in rail_service and chain_service
+    #: Extra parameters to pass to the guardrails LLM call.
+    # extra_params: ClassVar[dict[str, Any]] = {}
 
     def get_string_params(self) -> dict[str, str]:
         """

--- a/autopr/models/prompt_chains.py
+++ b/autopr/models/prompt_chains.py
@@ -17,16 +17,7 @@ class PromptChain(PromptBase):
     - write a prompt template in the `prompt_template` class variable, referencing parameters as {param}
     - define your parameters as pydantic instance attributes
     - optionally define an output parser as the `output_parser` class variable
-
-    Instance attributes declared in the PromptChain are automatically filled into the
-    `prompt_template` template string, wherever they are referenced as {param}.
     """
-
-    #: The prompt template to use for the langchain call (reference string parameters as {param}).
-    prompt_template: ClassVar[str] = ''
-
-    #: Extra parameters to pass to the langchain call.
-    # extra_params: ClassVar[dict[str, Any]] = {}
 
     #: The output parser to run the response through.
     output_parser: ClassVar[Optional[Type[BaseOutputParser]]] = None

--- a/autopr/models/prompt_chains.py
+++ b/autopr/models/prompt_chains.py
@@ -26,7 +26,7 @@ class PromptChain(PromptBase):
     prompt_template: ClassVar[str] = ''
 
     #: Extra parameters to pass to the langchain call.
-    extra_params: ClassVar[dict[str, Any]] = {}
+    # extra_params: ClassVar[dict[str, Any]] = {}
 
     #: The output parser to run the response through.
     output_parser: ClassVar[Optional[Type[BaseOutputParser]]] = None

--- a/autopr/models/prompt_rails.py
+++ b/autopr/models/prompt_rails.py
@@ -31,7 +31,7 @@ class PromptRail(PromptBase):
     prompt_spec: ClassVar[str] = ''
 
     #: Extra parameters to pass to the guardrails LLM call.
-    extra_params: ClassVar[dict[str, Any]] = {}
+    # extra_params: ClassVar[dict[str, Any]] = {}
 
     #: The RailObject type to parse the LLM response into.
     output_type: ClassVar[typing.Type[RailObject]]

--- a/autopr/models/prompt_rails.py
+++ b/autopr/models/prompt_rails.py
@@ -2,6 +2,7 @@ import typing
 from typing import ClassVar, Any
 import pydantic
 
+from autopr.models.prompt_base import PromptBase
 from autopr.models.rail_objects import RailObject
 
 import structlog
@@ -9,7 +10,7 @@ import structlog
 log = structlog.get_logger()
 
 
-class PromptRail(pydantic.BaseModel):
+class PromptRail(PromptBase):
     """
     A prompt rail is a pydantic model used to specify a prompt for a guardrails LLM call.
     See RailObject, RailService, and [Guardrails docs](https://docs.guardrails.io/) for more information.
@@ -34,33 +35,3 @@ class PromptRail(pydantic.BaseModel):
 
     #: The RailObject type to parse the LLM response into.
     output_type: ClassVar[typing.Type[RailObject]]
-
-    def get_string_params(self) -> dict[str, str]:
-        """
-        Get the parameters of the prompt as a dictionary of strings.
-        Override this method to specify your own parameters.
-        """
-        prompt_params = {}
-        for key, value in self:
-            if isinstance(value, list):
-                prompt_params[key] = '\n\n'.join(
-                    [str(item) for item in value]
-                )
-            else:
-                prompt_params[key] = str(value)
-        return prompt_params
-
-    def trim_params(self) -> bool:
-        """
-        This is called when the prompt is too long.
-        Override this method to trim the parameters of the prompt.
-        """
-
-        log.warning("Naively trimming params", rail=self)
-        prompt_params = dict(self)
-        # If there are any lists, remove the last element of the first one you find
-        for key, value in prompt_params.items():
-            if isinstance(value, list) and len(value) > 0:
-                setattr(self, key, value[:-1])
-                return True
-        return False

--- a/autopr/models/prompt_rails.py
+++ b/autopr/models/prompt_rails.py
@@ -17,18 +17,18 @@ class PromptRail(PromptBase):
 
     To define your own prompt rail:
     - declare your output type by subclassing RailObject, and referencing it in the `output_type` class variable
-    - write a prompt template in the `prompt_spec` class variable, referencing parameters as {param}
+    - write a prompt in the `prompt_template` class variable, referencing parameters as {param}
     - define your parameters as pydantic instance attributes
 
     Instance attributes declared in the PromptRail are automatically filled into the
-    `prompt_spec` template string, wherever they are referenced as {param}.
+    `prompt_template` string, wherever they are referenced as {param}.
     """
 
     #: Whether to invoke the guardrails LLM call on the output of an ordinary LLM call, or just by itself.
     two_step: ClassVar[bool] = True
 
     #: The prompt template to use for the guardrails LLM call (reference string parameters as {param}).
-    prompt_spec: ClassVar[str] = ''
+    prompt_template: ClassVar[str] = ''
 
     #: Extra parameters to pass to the guardrails LLM call.
     # extra_params: ClassVar[dict[str, Any]] = {}

--- a/autopr/models/prompt_rails.py
+++ b/autopr/models/prompt_rails.py
@@ -19,19 +19,10 @@ class PromptRail(PromptBase):
     - declare your output type by subclassing RailObject, and referencing it in the `output_type` class variable
     - write a prompt in the `prompt_template` class variable, referencing parameters as {param}
     - define your parameters as pydantic instance attributes
-
-    Instance attributes declared in the PromptRail are automatically filled into the
-    `prompt_template` string, wherever they are referenced as {param}.
     """
 
     #: Whether to invoke the guardrails LLM call on the output of an ordinary LLM call, or just by itself.
     two_step: ClassVar[bool] = True
-
-    #: The prompt template to use for the guardrails LLM call (reference string parameters as {param}).
-    prompt_template: ClassVar[str] = ''
-
-    #: Extra parameters to pass to the guardrails LLM call.
-    # extra_params: ClassVar[dict[str, Any]] = {}
 
     #: The RailObject type to parse the LLM response into.
     output_type: ClassVar[typing.Type[RailObject]]

--- a/autopr/services/chain_service.py
+++ b/autopr/services/chain_service.py
@@ -56,9 +56,13 @@ class ChainService:
         self,
         completions_repo: CompletionsRepo,
         publish_service: PublishService,
+        context_limit: int = 8192,
+        min_tokens: int = 2000,
     ):
         self.completions_repo = completions_repo
         self.publish_service = publish_service
+        self.context_limit = context_limit
+        self.min_tokens = min_tokens
 
         # TODO find a better way to integrate completions repo with langchain
         #   can we make a BaseLanguageModel that takes a completions repo?
@@ -121,6 +125,12 @@ class ChainService:
             return self.model(template.to_string())
 
     def run_chain(self, chain: PromptChain) -> Any:
+        # Make sure the prompt is not too long
+        max_length = self.context_limit - self.min_tokens
+        success = chain.ensure_token_length(max_length)
+        if not success:
+            return None
+
         self.publish_service.publish_update(f"Running chain {chain.__class__.__name__}")
         if chain.output_parser:
             parser = chain.output_parser()

--- a/autopr/services/rail_service.py
+++ b/autopr/services/rail_service.py
@@ -178,14 +178,14 @@ class RailService:
         :return:
         """
         # Make sure there are at least `min_tokens` tokens left
-        token_length = self.calculate_prompt_length(rail)
+        token_length = rail.calculate_prompt_token_length()
         while self.context_limit - token_length < self.min_tokens:
             # Trim the params (by default drops an item from a list)
             if not rail.trim_params():
                 rail_name = rail.__class__.__name__
                 log.debug(f'Could not trim params on rail {rail_name}: {rail.get_string_params()}')
                 return None
-            token_length = self.calculate_prompt_length(rail)
+            token_length = rail.calculate_prompt_token_length()
 
         suffix = "two steps" if rail.two_step else "one step"
         self.publish_service.publish_update(f"Running rail {rail.__class__.__name__} in {suffix}...")
@@ -209,10 +209,6 @@ class RailService:
         spec = rail_object.get_rail_spec()
         pr_guard = gr.Guard.from_rail_string(spec)
         return pr_guard.base_prompt.format(raw_document=raw_document)
-
-    def calculate_prompt_length(self, rail: PromptRail) -> int:
-        prompt = rail.get_prompt_message()
-        return len(self.completions_repo.tokenizer.encode(prompt))
 
     def calculate_rail_length(self, rail_object: Type[RailObject], raw_document: str) -> int:
         rail_message = self.get_rail_message(rail_object, raw_document)

--- a/autopr/services/rail_service.py
+++ b/autopr/services/rail_service.py
@@ -38,7 +38,7 @@ class RailService:
 
         class MyPromptRail(PromptRail):
             output_type = Colors
-            prompt_spec = "What colors is {something}?"
+            prompt_template = "What colors is {something}?"
 
             something: str
 
@@ -48,7 +48,7 @@ class RailService:
         print(colors)  # colors=['black', 'white']
 
     This service is responsible for:
-    - Compiling prompts according to `PromptRail.prompt_spec`, `RailObject.output_spec`,
+    - Compiling prompts according to `PromptRail.prompt_template`, `RailObject.output_spec`,
       and `RailObject.get_rail_spec()`
     - Invoking a guardrail LLM calls,
       optionally after an ordinary LLM call if `PromptRail.two_step` is True
@@ -206,7 +206,7 @@ class RailService:
 
     @staticmethod
     def get_prompt_message(rail: PromptRail):
-        spec = rail.prompt_spec
+        spec = rail.prompt_template
         prompt_params = rail.get_string_params()
         return spec.format(**prompt_params)
 

--- a/autopr/services/rail_service.py
+++ b/autopr/services/rail_service.py
@@ -190,7 +190,7 @@ class RailService:
         suffix = "two steps" if rail.two_step else "one step"
         self.publish_service.publish_update(f"Running rail {rail.__class__.__name__} in {suffix}...")
 
-        prompt = self.get_prompt_message(rail)
+        prompt = rail.get_prompt_message()
         if rail.two_step:
             initial_prompt = prompt
             prompt = self.completions_repo.complete(
@@ -205,19 +205,13 @@ class RailService:
         return self.run_rail_object(rail.output_type, prompt)
 
     @staticmethod
-    def get_prompt_message(rail: PromptRail):
-        spec = rail.prompt_template
-        prompt_params = rail.get_string_params()
-        return spec.format(**prompt_params)
-
-    @staticmethod
     def get_rail_message(rail_object: type[RailObject], raw_document: str):
         spec = rail_object.get_rail_spec()
         pr_guard = gr.Guard.from_rail_string(spec)
         return pr_guard.base_prompt.format(raw_document=raw_document)
 
     def calculate_prompt_length(self, rail: PromptRail) -> int:
-        prompt = self.get_prompt_message(rail)
+        prompt = rail.get_prompt_message()
         return len(self.completions_repo.tokenizer.encode(prompt))
 
     def calculate_rail_length(self, rail_object: Type[RailObject], raw_document: str) -> int:

--- a/autopr/utils/tokenizer.py
+++ b/autopr/utils/tokenizer.py
@@ -1,9 +1,13 @@
+from typing import Optional
+
 import transformers
 
-_tokenizer_cache: dict[int, transformers.GPT2TokenizerFast] = {}
+# FIXME use tiktoken instead
+
+_tokenizer_cache: dict[Optional[int], transformers.GPT2TokenizerFast] = {}
 
 
-def get_tokenizer(model_max_length: int):
+def get_tokenizer(model_max_length: Optional[int] = None):
     global _tokenizer_cache
 
     if model_max_length not in _tokenizer_cache:


### PR DESCRIPTION
Fixes #76 

This PR refactors the guardrails and langchain prompt specifications into a base prompt class.
After moving the prompt length logic from `rail_service` to the `PromptBase`, `chain_service` now also trims the prompt to allow `min_tokens` for response.