### PR TITLE
Add RequestMoreInformation action

### DIFF
--- a/autopr/actions/request_more_info.py
+++ b/autopr/actions/request_more_info.py
@@ -1,0 +1,28 @@
+from autopr.actions.base import Action, ContextDict
+from autopr.models.artifacts import Issue
+
+
+class RequestMoreInfo(Action):
+    id = "request_more_information"
+    description = "Request more information from the user."
+
+    class Arguments(Action.Arguments):
+        message: str
+
+        output_spec = "<string name='message'/>"
+
+    def run(self, arguments: Arguments, context: ContextDict) -> ContextDict:
+        # Get the issue from the context
+        issue = context['issue']
+        if not isinstance(issue, Issue):
+            self.log.error(f"Expected issue to be of type Issue, got {type(issue)}")
+            raise TypeError(f"Expected issue to be of type Issue, got {type(issue)}")
+
+        # Get the message from the arguments
+        message = arguments.message
+
+        # Add a comment to the issue
+        self.publish_service.comment_on_issue(message)
+
+        # Return the context
+        return context

--- a/autopr/actions/request_more_info.py
+++ b/autopr/actions/request_more_info.py
@@ -22,7 +22,10 @@ class RequestMoreInfo(Action):
         message = arguments.message
 
         # Add a comment to the issue
-        self.publish_service.comment_on_issue(message)
+        success = self.publish_service.comment_on_issue(message)
+        if not success:
+            self.log.error(f"Failed to comment on issue")
+            raise RuntimeError(f"Failed to comment on issue")
 
         # Return the context
         return context

--- a/autopr/agents/plan_and_code.py
+++ b/autopr/agents/plan_and_code.py
@@ -25,6 +25,7 @@ class PlanAndCode(Agent):
         *args,
         planning_actions: Collection[str] = (
             "plan_pull_request",
+            "request_more_information"
         ),
         codegen_actions: Collection[str] = (
             'new_file',

--- a/autopr/services/publish_service.py
+++ b/autopr/services/publish_service.py
@@ -363,6 +363,17 @@ class PublishService:
         title = self.pr_title
         self._publish_pull_request(title, body, success=success)
 
+    def comment_on_issue(self, text: str):
+        """
+        Comment on the issue with the given text.
+
+        Parameters
+        ----------
+        text: str
+            The text to comment
+        """
+        raise NotImplementedError
+
     def _publish_pull_request(
         self,
         title: str,
@@ -580,6 +591,23 @@ AutoPR encountered an error while trying to fix {issue_link}.
             self.log.error('Failed to get pull requests', response_text=response.text)
 
         return None
+
+    def comment_on_issue(self, text: str):
+        url = f'https://api.github.com/repos/{self.owner}/{self.repo}/issues/{self.issue.number}/comments'
+        headers = self._get_headers()
+        data = {
+            'body': text,
+        }
+        response = requests.post(url, json=data, headers=headers)
+
+        if response.status_code == 201:
+            self.log.debug('Commented on issue successfully')
+            return
+
+        self.log.error('Failed to comment on issue',
+                       code=response.status_code,
+                       response=response.json(),
+                       headers=response.headers)
 
 
 class DummyPublishService(PublishService):

--- a/autopr/services/publish_service.py
+++ b/autopr/services/publish_service.py
@@ -363,7 +363,7 @@ class PublishService:
         title = self.pr_title
         self._publish_pull_request(title, body, success=success)
 
-    def comment_on_issue(self, text: str):
+    def comment_on_issue(self, text: str) -> bool:
         """
         Comment on the issue with the given text.
 
@@ -592,7 +592,7 @@ AutoPR encountered an error while trying to fix {issue_link}.
 
         return None
 
-    def comment_on_issue(self, text: str):
+    def comment_on_issue(self, text: str) -> bool:
         url = f'https://api.github.com/repos/{self.owner}/{self.repo}/issues/{self.issue.number}/comments'
         headers = self._get_headers()
         data = {
@@ -602,12 +602,13 @@ AutoPR encountered an error while trying to fix {issue_link}.
 
         if response.status_code == 201:
             self.log.debug('Commented on issue successfully')
-            return
+            return True
 
         self.log.error('Failed to comment on issue',
                        code=response.status_code,
                        response=response.json(),
                        headers=response.headers)
+        return False
 
 
 class DummyPublishService(PublishService):


### PR DESCRIPTION
Fixes #93 

This action adds a comment in the issue, it's invoked when there's not enough information given.

Also add it as one of the default planning actions on the agent.