### PR TITLE
Publish progress updates in both PR body and comments

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -63,6 +63,7 @@ you need to sign up on [the GPT-4 API waitlist](https://openai.com/waitlist/gpt-
 - `rail_temperature`: The temperature for the guardrails calls. Defaults to `0.9`.
 - `agent_id`: The ID of the agent to use. Defaults to `plan_and_code`.
 - `agent_config`: The configuration for the agent. Empty by default.
+- `overwrite_existing`: Whether to overwrite the branch being generated for the issue instead of always making a new pull request. Defaults to `false`.
 
 Specify `agent_config` as a yaml string, e.g.:
 

--- a/action.yml
+++ b/action.yml
@@ -46,3 +46,6 @@ inputs:
   rail_temperture:
     description: 'Temperature for the guardrails calls'
     default: '0.9'
+  overwrite_existing:
+    description: 'Whether to overwrite existing branches and pull requests when creating from issues'
+    default: 'false'

--- a/autopr/actions/request_more_info.py
+++ b/autopr/actions/request_more_info.py
@@ -22,7 +22,7 @@ class RequestMoreInfo(Action):
         message = arguments.message
 
         # Add a comment to the issue
-        success = self.publish_service.comment_on_issue(message)
+        success = self.publish_service.publish_comment(message, issue.number)
         if not success:
             self.log.error(f"Failed to comment on issue")
             raise RuntimeError(f"Failed to comment on issue")

--- a/autopr/agents/plan_and_code.py
+++ b/autopr/agents/plan_and_code.py
@@ -116,7 +116,7 @@ class PlanAndCode(Agent):
 
         # Publish the description
         self.publish_service.set_title(pr_desc.title)
-        self.publish_service.publish_comment(pr_desc.body)
+        self.publish_service.publish_comment(pr_desc.body, issue.number)
 
         for current_commit in pr_desc.commits:
             context = self.write_commit(

--- a/autopr/agents/plan_and_code.py
+++ b/autopr/agents/plan_and_code.py
@@ -115,7 +115,8 @@ class PlanAndCode(Agent):
                             f"{type(pr_desc)} instead of PullRequestDescription")
 
         # Publish the description
-        self.publish_service.set_pr_description(pr_desc.title, pr_desc.body)
+        self.publish_service.set_title(pr_desc.title)
+        self.publish_service.publish_comment(pr_desc.body)
 
         for current_commit in pr_desc.commits:
             context = self.write_commit(

--- a/autopr/gh_actions_entrypoint.py
+++ b/autopr/gh_actions_entrypoint.py
@@ -74,9 +74,13 @@ if __name__ == '__main__':
     if isinstance(event, IssueLabelEvent):
         branch_name = settings.target_branch_name_template.format(issue_number=event.issue.number)
         base_branch = settings.base_branch
+        issue = event.issue
+        pull_request_number = None
     else:
         branch_name = event.pull_request.head_branch
         base_branch = event.pull_request.base_branch
+        issue = None
+        pull_request_number = event.pull_request.number
 
     # Create commit service
     commit_service = CommitService(
@@ -88,13 +92,14 @@ if __name__ == '__main__':
 
     # Create publish service
     publish_service = GitHubPublishService(
-        issue=event.issue,
         token=github_token,
         owner=owner,
         repo_name=repo_name,
         head_branch=branch_name,
         base_branch=settings.base_branch,
         run_id=run_id,
+        issue=issue,
+        pull_request_number=pull_request_number,
         loading_gif_url=settings.loading_gif_url,
     )
 

--- a/autopr/gh_actions_entrypoint.py
+++ b/autopr/gh_actions_entrypoint.py
@@ -2,15 +2,11 @@ import json
 import os
 from typing import Any
 
-from git.repo import Repo
-
-from autopr.main import main, Settings
+from autopr.main import Settings, MainService
 
 import yaml
 
 from autopr.log_config import configure_logging
-from autopr.models.events import IssueLabelEvent
-from autopr.services.commit_service import CommitService
 from autopr.services.event_service import GitHubEventService
 from autopr.services.publish_service import GitHubPublishService
 
@@ -31,82 +27,43 @@ class GitHubActionSettings(Settings):
             return cls.json_loads(raw_val)  # type: ignore
 
 
+class GithubMainService(MainService):
+    settings_class = GitHubActionSettings
+    publish_service_class = GitHubPublishService
+
+    def get_repo_path(self):
+        return os.environ['GITHUB_WORKSPACE']
+
+    def get_event(self):
+        github_token = os.environ['INPUT_GITHUB_TOKEN']
+        event_name = os.environ['GITHUB_EVENT_NAME']
+        event_path = os.environ['GITHUB_EVENT_PATH']
+
+        # Load event
+        with open(event_path, 'r') as f:
+            event_json = json.load(f)
+
+        print(json.dumps(event_json, indent=2))
+
+        # Extract event
+        event_service = GitHubEventService(
+            github_token=github_token,
+        )
+        return event_service.parse_event(event_name, event_json)
+
+    def get_publish_service(self, **additional_kwargs):
+        github_token = os.environ['INPUT_GITHUB_TOKEN']
+        run_id = os.environ['GITHUB_RUN_ID']
+
+        return super().get_publish_service(
+            token=github_token,
+            run_id=run_id,
+            **additional_kwargs,
+        )
+
+
 if __name__ == '__main__':
     log.info("Starting gh_actions_entrypoint.py")
 
-    # Get input variables
-    settings = GitHubActionSettings.parse_obj({})  # pyright workaround
-
-    # Get github vars
-    github_token = os.environ['INPUT_GITHUB_TOKEN']
-    repo_path = os.environ['GITHUB_WORKSPACE']
-    run_id = os.environ['GITHUB_RUN_ID']
-    event_name = os.environ['GITHUB_EVENT_NAME']
-    event_path = os.environ['GITHUB_EVENT_PATH']
-
-    # Load event
-    with open(event_path, 'r') as f:
-        event_json = json.load(f)
-
-    log.info("Got input variables",
-             settings=settings,
-             repo_path=repo_path,
-             run_id=run_id,
-             event_name=event_name,
-             event_path=event_path)
-
-    print(json.dumps(event_json, indent=2))
-
-    # Extract event
-    event_service = GitHubEventService(
-        github_token=github_token,
-    )
-    event = event_service.parse_event(event_name, event_json)
-
-    # Instantiate repo
-    repo = Repo(repo_path)
-
-    # Get repo owner and name from remote URL
-    remote_url = repo.remotes.origin.url
-    owner, repo_name = remote_url.removesuffix(".git").split('/')[-2:]
-
-    # Format branch name
-    if isinstance(event, IssueLabelEvent):
-        branch_name = settings.target_branch_name_template.format(issue_number=event.issue.number)
-        base_branch = settings.base_branch
-        issue = event.issue
-        pull_request_number = None
-    else:
-        branch_name = event.pull_request.head_branch
-        base_branch = event.pull_request.base_branch
-        issue = None
-        pull_request_number = event.pull_request.number
-
-    # Create commit service
-    commit_service = CommitService(
-        repo=repo,
-        repo_path=repo_path,
-        branch_name=branch_name,
-        base_branch_name=base_branch,
-    )
-
-    # Create publish service
-    publish_service = GitHubPublishService(
-        token=github_token,
-        owner=owner,
-        repo_name=repo_name,
-        head_branch=branch_name,
-        base_branch=settings.base_branch,
-        run_id=run_id,
-        issue=issue,
-        pull_request_number=pull_request_number,
-        loading_gif_url=settings.loading_gif_url,
-    )
-
-    main(
-        repo_path=repo_path,
-        event=event,
-        commit_service=commit_service,
-        publish_service=publish_service,
-        settings=settings,
-    )
+    main_service = GithubMainService()
+    main_service.run()

--- a/autopr/main.py
+++ b/autopr/main.py
@@ -22,7 +22,7 @@ class Settings(BaseSettings):
 
     base_branch: str = 'main'
     target_branch_name_template: str = 'autopr/{issue_number}'
-    overwrite_existing_branch: bool = False
+    overwrite_existing: bool = False
     loading_gif_url: str = "https://media0.giphy.com/media/l3nWhI38IWDofyDrW/giphy.gif"
     model: str = "gpt-4"
     temperature: float = 0.8
@@ -134,14 +134,14 @@ class MainService:
             issue=issue,
             pull_request_number=pull_request_number,
             loading_gif_url=self.settings.loading_gif_url,
-            overwrite_existing=self.settings.overwrite_existing_branch,
+            overwrite_existing=self.settings.overwrite_existing,
             **additional_kwargs,
         )
 
     def get_branch_name(self):
         if isinstance(self.event, IssueLabelEvent):
             branch_name = self.settings.target_branch_name_template.format(issue_number=self.event.issue.number)
-            if not self.settings.overwrite_existing_branch:
+            if not self.settings.overwrite_existing:
                 # check if branch exists, if so, append a number to the end
                 remote = self.repo.remote()
                 references = remote.fetch()

--- a/autopr/main.py
+++ b/autopr/main.py
@@ -98,5 +98,5 @@ def main(
         action_service=action_service,
     )
 
-    # Generate and set_pr_description the PR
+    # Generate the PR
     agent_service.run_agent(settings.agent_id, settings.agent_config, event)

--- a/autopr/main.py
+++ b/autopr/main.py
@@ -1,24 +1,19 @@
-from typing import Optional, Any
+from typing import Optional, Any, Type
 
-import openai
 from git.repo import Repo
 from pydantic import BaseSettings
 
-from .models.artifacts import Issue
-from .models.events import EventUnion
-from .repos.completions_repo import OpenAICompletionsRepo, OpenAIChatCompletionsRepo, get_completions_repo
+from .models.events import EventUnion, IssueLabelEvent
+from .repos.completions_repo import get_completions_repo
 from .services.action_service import ActionService
 from .services.agent_service import AgentService
 from .services.chain_service import ChainService
 from .services.commit_service import CommitService
-from .services.diff_service import GitApplyService, PatchService
-from .services.event_service import EventService, GitHubEventService
-from .services.publish_service import GitHubPublishService, PublishService
+from .services.diff_service import GitApplyService
+from .services.publish_service import PublishService
 from .services.rail_service import RailService
 
 import structlog
-
-log = structlog.get_logger()
 
 
 class Settings(BaseSettings):
@@ -27,6 +22,7 @@ class Settings(BaseSettings):
 
     base_branch: str = 'main'
     target_branch_name_template: str = 'autopr/{issue_number}'
+    overwrite_existing_branch: bool = False
     loading_gif_url: str = "https://media0.giphy.com/media/l3nWhI38IWDofyDrW/giphy.gif"
     model: str = "gpt-4"
     temperature: float = 0.8
@@ -37,66 +33,129 @@ class Settings(BaseSettings):
     num_reasks: int = 2
 
 
-def main(
-    repo_path: str,
-    event: EventUnion,
-    commit_service: CommitService,
-    publish_service: PublishService,
-    settings: Settings,
-):
-    log.info('Starting main',
-             repo_path=repo_path,
-             settings=settings)
+class MainService:
+    settings_class: Type[Settings] = Settings
+    publish_service_class: Type[PublishService] = PublishService
 
-    # Instantiate repo
-    repo = Repo(repo_path)
+    def __init__(self):
+        self.log = structlog.get_logger()
 
-    # Create completions repo
-    completions_repo = get_completions_repo(
-        publish_service=publish_service,
-        model=settings.model,
-        context_limit=settings.context_limit,
-        min_tokens=settings.min_tokens,
-        max_tokens=settings.max_tokens,
-        temperature=settings.temperature,
-    )
+        self.settings = settings = self.settings_class.parse_obj({})  # pyright workaround
+        self.event = self.get_event()
+        self.repo_path = self.get_repo_path()
+        self.repo = Repo(self.repo_path)
+        self.branch_name = self.get_branch_name()
+        self.base_branch_name = self.get_base_branch_name()
+        self.publish_service = self.get_publish_service()
 
-    # Create rail and chain service
-    rail_service = RailService(
-        completions_repo=completions_repo,
-        min_tokens=settings.min_tokens,
-        context_limit=settings.context_limit,
-        num_reasks=settings.num_reasks,
-        temperature=settings.rail_temperature,
-        publish_service=publish_service,
-    )
-    chain_service = ChainService(
-        completions_repo=completions_repo,
-        publish_service=publish_service,
-        context_limit=settings.context_limit,
-        min_tokens=settings.min_tokens,
-    )
+        # Create commit service
+        commit_service = CommitService(
+            repo=self.repo,
+            repo_path=self.repo_path,
+            branch_name=self.branch_name,
+            base_branch_name=self.base_branch_name,
+        )
+        commit_service.overwrite_new_branch()
 
-    # Create diff service
-    diff_service = GitApplyService(repo=repo)
+        # Create completions repo
+        completions_repo = get_completions_repo(
+            publish_service=self.publish_service,
+            model=settings.model,
+            context_limit=settings.context_limit,
+            min_tokens=settings.min_tokens,
+            max_tokens=settings.max_tokens,
+            temperature=settings.temperature,
+        )
 
-    # Create action service and agent service
-    action_service = ActionService(
-        repo=repo,
-        completions_repo=completions_repo,
-        rail_service=rail_service,
-        publish_service=publish_service,
-        chain_service=chain_service,
-    )
-    agent_service = AgentService(
-        repo=repo,
-        publish_service=publish_service,
-        rail_service=rail_service,
-        chain_service=chain_service,
-        diff_service=diff_service,
-        commit_service=commit_service,
-        action_service=action_service,
-    )
+        # Create rail and chain service
+        rail_service = RailService(
+            completions_repo=completions_repo,
+            min_tokens=settings.min_tokens,
+            context_limit=settings.context_limit,
+            num_reasks=settings.num_reasks,
+            temperature=settings.rail_temperature,
+            publish_service=self.publish_service,
+        )
+        chain_service = ChainService(
+            completions_repo=completions_repo,
+            publish_service=self.publish_service,
+            context_limit=settings.context_limit,
+            min_tokens=settings.min_tokens,
+        )
 
-    # Generate the PR
-    agent_service.run_agent(settings.agent_id, settings.agent_config, event)
+        # Create diff service
+        diff_service = GitApplyService(repo=self.repo)
+
+        # Create action service and agent service
+        action_service = ActionService(
+            repo=self.repo,
+            completions_repo=completions_repo,
+            rail_service=rail_service,
+            publish_service=self.publish_service,
+            chain_service=chain_service,
+        )
+        self.agent_service = AgentService(
+            repo=self.repo,
+            publish_service=self.publish_service,
+            rail_service=rail_service,
+            chain_service=chain_service,
+            diff_service=diff_service,
+            commit_service=commit_service,
+            action_service=action_service,
+        )
+
+    def run(self):
+        # Generate the PR
+        self.agent_service.run_agent(self.settings.agent_id, self.settings.agent_config, self.event)
+
+    def get_repo_path(self):
+        raise NotImplementedError
+
+    def get_event(self) -> EventUnion:
+        raise NotImplementedError
+
+    def get_publish_service(self, **additional_kwargs):
+        # Get repo owner and name from remote URL
+        remote_url = self.repo.remotes.origin.url
+        owner, repo_name = remote_url.removesuffix(".git").split('/')[-2:]
+
+        if isinstance(self.event, IssueLabelEvent):
+            issue = self.event.issue
+            pull_request_number = None
+        else:
+            issue = None
+            pull_request_number = self.event.pull_request.number
+
+        return self.publish_service_class(
+            owner=owner,
+            repo_name=repo_name,
+            head_branch=self.branch_name,
+            base_branch=self.base_branch_name,
+            issue=issue,
+            pull_request_number=pull_request_number,
+            loading_gif_url=self.settings.loading_gif_url,
+            overwrite_existing=self.settings.overwrite_existing_branch,
+            **additional_kwargs,
+        )
+
+    def get_branch_name(self):
+        if isinstance(self.event, IssueLabelEvent):
+            branch_name = self.settings.target_branch_name_template.format(issue_number=self.event.issue.number)
+            if not self.settings.overwrite_existing_branch:
+                # check if branch exists, if so, append a number to the end
+                remote = self.repo.remote()
+                references = remote.fetch()
+                i = 2
+                while f'{remote.name}/{branch_name}' in [ref.name for ref in references]:
+                    branch_name = self.settings.target_branch_name_template.format(
+                        issue_number=self.event.issue.number) + f'-{i}'
+                    i += 1
+            return branch_name
+        else:
+            return self.event.pull_request.head_branch
+
+    def get_base_branch_name(self):
+        if isinstance(self.event, IssueLabelEvent):
+            return self.settings.base_branch
+        else:
+            return self.event.pull_request.base_branch

--- a/autopr/services/publish_service.py
+++ b/autopr/services/publish_service.py
@@ -705,7 +705,7 @@ Pull Request: {pr_link}
         self._patch_pr(pr_number, {'title': title})
 
     def _update_pr_comment(self, comment_id: str, body: str):
-        url = f'https://api.github.com/repos/{self.owner}/{self.repo_name}/pulls/comments/{comment_id}'
+        url = f'https://api.github.com/repos/{self.owner}/{self.repo_name}/issues/comments/{comment_id}'
         headers = self._get_headers()
         response = requests.patch(url, json={'body': body}, headers=headers)
 

--- a/autopr/services/publish_service.py
+++ b/autopr/services/publish_service.py
@@ -74,7 +74,8 @@ class PublishService:
         self.loading_gif_url = loading_gif_url
         self.overwrite_existing = overwrite_existing
 
-        self.max_comment_length = 60000
+        # GitHub comment length limit is ~262144, not 65536 as stated in the docs
+        self.max_comment_length = 260000
 
         if issue is not None:
             self.title: str = f"Fix #{issue.number}: {issue.title}"

--- a/autopr/services/publish_service.py
+++ b/autopr/services/publish_service.py
@@ -474,7 +474,8 @@ class GitHubPublishService(PublishService):
         )
         self.token = token
         self.run_id = run_id
-        self.pr_node_id = None
+
+        self.pr_node_id: Optional[str] = None
 
         self._drafts_supported = True
 
@@ -570,7 +571,7 @@ Pull Request: {pr_link}
                 self.pr_node_id = self._get_pull_request_node_id(self.pr_number)
             self._set_pr_draft_status(self.pr_node_id, not success)
 
-    def _find_existing_pr(self) -> dict[str, Any]:
+    def _find_existing_pr(self) -> Optional[dict[str, Any]]:
         """
         Returns the PR dict of the first open pull request with the same head and base branches
         """
@@ -671,7 +672,7 @@ Pull Request: {pr_link}
             self._drafts_supported = False
         return is_draft_error
 
-    def _get_pull_request_node_id(self, pr_number: int) -> str:
+    def _get_pull_request_node_id(self, pr_number: str) -> str:
         url = f'https://api.github.com/repos/{self.owner}/{self.repo_name}/pulls/{pr_number}'
         headers = self._get_headers()
         response = requests.get(url, headers=headers)
@@ -686,7 +687,7 @@ Pull Request: {pr_link}
                            headers=response.headers)
             raise RuntimeError('Failed to get pull request node id')
 
-    def _set_pr_draft_status(self, pr_node_id: int, is_draft: bool):
+    def _set_pr_draft_status(self, pr_node_id: str, is_draft: bool):
         # sadly this is only supported by graphQL
         if is_draft:
             graphql_query = '''

--- a/autopr/services/publish_service.py
+++ b/autopr/services/publish_service.py
@@ -286,29 +286,6 @@ class PublishService:
 
         return progress
 
-    def _build_issue_template_link(self, **kwargs):
-        if sys.exc_info()[0] is not None:
-            error = traceback.format_exc()
-        else:
-            error = "No traceback"
-        kwargs['error'] = error
-
-        body = self.error_report_template.format(**kwargs)
-        if sys.exc_info()[0] is not None:
-            title = traceback.format_exception_only(sys.exc_info()[0], sys.exc_info()[1])[0].strip()
-        elif self.issue is not None:
-            title = f'Error fixing "{self.issue.title}"'
-        else:
-            title = "Error running AutoPR"
-
-        issue_link = self.new_error_report_link_template.format(
-            body=body,
-            title=title,
-        )
-        # Map characters to their URL-encoded equivalents
-        encoded_url = issue_link.replace(' ', '%20').replace('\n', '%0A').replace('"', '%22').replace("#", "%23")
-        return encoded_url
-
     def _build_bodies(self, success: Optional[bool] = None) -> list[str]:
         """
         Builds the body of the pull request, splitting it into multiple bodies if necessary.
@@ -358,7 +335,31 @@ class PublishService:
                     f'<img src="{self.loading_gif_url}"' \
                     f' width="200" height="200"/>'
         bodies += [body]
+        self.log.debug("Built bodies", bodies=bodies)
         return bodies
+
+    def _build_issue_template_link(self, **kwargs):
+        if sys.exc_info()[0] is not None:
+            error = traceback.format_exc()
+        else:
+            error = "No traceback"
+        kwargs['error'] = error
+
+        body = self.error_report_template.format(**kwargs)
+        if sys.exc_info()[0] is not None:
+            title = traceback.format_exception_only(sys.exc_info()[0], sys.exc_info()[1])[0].strip()
+        elif self.issue is not None:
+            title = f'Error fixing "{self.issue.title}"'
+        else:
+            title = "Error running AutoPR"
+
+        issue_link = self.new_error_report_link_template.format(
+            body=body,
+            title=title,
+        )
+        # Map characters to their URL-encoded equivalents
+        encoded_url = issue_link.replace(' ', '%20').replace('\n', '%0A').replace('"', '%22').replace("#", "%23")
+        return encoded_url
 
     def update(self):
         """

--- a/autopr/services/publish_service.py
+++ b/autopr/services/publish_service.py
@@ -575,7 +575,14 @@ Pull Request: {pr_link}
             if prs:
                 return prs[0]  # Return the first pull request found
         else:
-            self.log.error('Failed to get pull requests', response_text=response.text)
+            self.log.error(
+                'Failed to get pull requests',
+                response_text=response.text,
+                request_url=url,
+                request_params=params,
+                code=response.status_code,
+                headers=response.headers,
+            )
 
         return None
 
@@ -601,12 +608,16 @@ Pull Request: {pr_link}
                     self.log.error('Failed to create pull request',
                                    code=response.status_code,
                                    response=response.json(),
+                                   request_url=url,
+                                   request_body=data,
                                    headers=response.headers)
                     raise RuntimeError('Failed to create pull request')
             else:
                 self.log.error('Failed to create pull request',
                                code=response.status_code,
                                response=response.json(),
+                               request_url=url,
+                               request_body=data,
                                headers=response.headers)
                 raise RuntimeError('Failed to create pull request')
 
@@ -637,6 +648,8 @@ Pull Request: {pr_link}
         self.log.error('Failed to update pull request',
                        code=response.status_code,
                        response=response.json(),
+                       request_url=url,
+                       request_body=data,
                        headers=response.headers)
 
     def _is_draft_error(self, response_text: str):
@@ -658,6 +671,8 @@ Pull Request: {pr_link}
             self.log.error('Failed to get pull request node id',
                            code=response.status_code,
                            response=response.json(),
+                           request_url=url,
+                           request_headers=headers,
                            headers=response.headers)
             raise RuntimeError('Failed to get pull request node id')
 
@@ -699,6 +714,7 @@ Pull Request: {pr_link}
         self.log.error('Failed to update pull request draft status',
                        code=response.status_code,
                        response=response.json(),
+                       request=graphql_query,
                        headers=response.headers)
         self._drafts_supported = False
 
@@ -720,6 +736,8 @@ Pull Request: {pr_link}
         self.log.error('Failed to update comment',
                        code=response.status_code,
                        response=response.json(),
+                       request_url=url,
+                       request_body={'body': body},
                        headers=response.headers)
 
     def _publish_comment(self, text: str, issue_number: int) -> Optional[str]:
@@ -737,6 +755,8 @@ Pull Request: {pr_link}
         self.log.error('Failed to comment on issue',
                        code=response.status_code,
                        response=response.json(),
+                       request_url=url,
+                       request_body=data,
                        headers=response.headers)
         return None
 

--- a/autopr/services/publish_service.py
+++ b/autopr/services/publish_service.py
@@ -476,7 +476,6 @@ class GitHubPublishService(PublishService):
         self.run_id = run_id
 
         self._drafts_supported = True
-        self._comment_id = None
 
         # list of comment IDs, incl. PRBodySentinel to denote the body of the PR
         self._comment_ids: list[Union[str, Type[GitHubPublishService.PRBodySentinel]]] = []

--- a/autopr/services/publish_service.py
+++ b/autopr/services/publish_service.py
@@ -326,7 +326,7 @@ class PublishService:
                 progress_update = str(section)
             if len(body) + len('\n\n' + progress_update) > self.max_comment_length:
                 bodies += [body]
-                body = f"## Progress Updates (continued)\n\n{progress_update}"
+                body = f"## Status (continued)\n\n{progress_update}"
             else:
                 body += f"\n\n{progress_update}"
 

--- a/autopr/services/publish_service.py
+++ b/autopr/services/publish_service.py
@@ -533,6 +533,10 @@ Pull Request: {pr_link}
         self._update_pr_title(self.pr_number, title)
 
     def _publish_progress(self, bodies: list[str], success: bool = False):
+        # If overwrite existing, find the PR number
+        if not self.pr_number and self.overwrite_existing:
+            self.pr_number = self._find_existing_pr()
+
         # If PR does not exist yet, create it
         if not self.pr_number:
             self.pr_number = self._create_pr(self.title, bodies, success)

--- a/autopr/tests/test_publish_service.py
+++ b/autopr/tests/test_publish_service.py
@@ -1,0 +1,56 @@
+from unittest.mock import patch, Mock
+
+from autopr.services.publish_service import GitHubPublishService
+
+
+@patch('requests.get')
+@patch('requests.post')
+@patch('requests.patch')
+def test_github_publish_service(mock_patch, mock_post, mock_get):
+    # Mock responses for each request call
+    mock_get.return_value = Mock(status_code=200, json=lambda: [{'number': 1, 'node_id': 'node1'}])
+    mock_post.return_value = Mock(status_code=201, json=lambda: {'number': 2, 'id': 'comment1'})
+    mock_patch.return_value = Mock(status_code=200, json=lambda: {})
+
+    service = GitHubPublishService(
+        token='my_token',
+        run_id='123',
+        owner='user',
+        repo_name='repo',
+        head_branch='branch1',
+        base_branch='branch2',
+        issue=None,
+        pull_request_number=None,
+        loading_gif_url="https://media.giphy.com/media/3oEjI6SIIHBdRxXI40/giphy.gif",
+        overwrite_existing=False,
+    )
+
+    # Test _find_existing_pr
+    pr = service._find_existing_pr()
+    assert pr['number'] == 1
+    assert pr['node_id'] == 'node1'
+
+    # Test _create_pr
+    pr = service._create_pr('title', ['body1', 'body2'], True)
+    assert pr['number'] == 2
+    assert service._comment_ids == [service.PRBodySentinel, 'comment1']
+
+    # Test _update_pr_body
+    service._update_pr_body(1, 'new body')
+    mock_patch.assert_called_with(
+        'https://api.github.com/repos/user/repo/pulls/1',
+        headers=service._get_headers(),
+        json={'body': 'new body'}
+    )
+
+    # Test _update_pr_comment
+    service._update_pr_comment('comment1', 'new comment')
+    mock_patch.assert_called_with(
+        'https://api.github.com/repos/user/repo/issues/comments/comment1',
+        headers=service._get_headers(),
+        json={'body': 'new comment'}
+    )
+
+    # Test _publish_comment
+    comment_id = service._publish_comment('new comment', 1)
+    assert comment_id == 'comment1'

--- a/autopr/tests/test_publish_service.py
+++ b/autopr/tests/test_publish_service.py
@@ -27,11 +27,13 @@ def test_github_publish_service(mock_patch, mock_post, mock_get):
 
     # Test _find_existing_pr
     pr = service._find_existing_pr()
+    assert pr is not None
     assert pr['number'] == 1
     assert pr['node_id'] == 'node1'
 
     # Test _create_pr
     pr = service._create_pr('title', ['body1', 'body2'], True)
+    assert pr is not None
     assert pr['number'] == 2
     assert service._comment_ids == [service.PRBodySentinel, 'comment1']
 


### PR DESCRIPTION
If progress report is too big, split it into multiple messages.
When re-running, don't overwrite branches/PRs/progress reports by default. You can use the `overwrite_existing` config option to overwrite the branch and PR on reruns, but it'll still write a new progress report in a new PR comment.
Refactor main function to a class, with github actions entrypoint as a subclass.